### PR TITLE
Delete calls in the admin panel and webchat embed endpoint 

### DIFF
--- a/.kiro/specs/call-log-deletion/.config.kiro
+++ b/.kiro/specs/call-log-deletion/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "d2426921-f8b6-4ce6-86bd-5c9e2f8fb3a6", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/call-log-deletion/design.md
+++ b/.kiro/specs/call-log-deletion/design.md
@@ -1,0 +1,239 @@
+# Design Document: Call Log Deletion
+
+## Overview
+
+This feature adds delete capabilities to the call logs page in the admin panel. Administrators can delete a single call log or all call logs at once. Call summaries are JSON files stored in `call-summaries/`. The implementation adds two new methods to `CallSummaryManager` (`deleteSummaryById`, `deleteAllSummaries`), two new Express DELETE endpoints, and UI controls (per-row delete button, "Delete All" button with confirmation dialogs) on the existing `calls.html` page.
+
+### Key Design Decisions
+
+1. **DELETE HTTP methods** — Uses `DELETE /admin/api/calls/:id` and `DELETE /admin/api/calls` to follow REST conventions. Both routes sit behind the existing IP whitelist and auth middleware, so no new auth logic is needed.
+2. **Path traversal prevention** — All ID parameters are sanitized with `path.basename()` in both the server route handler and the `CallSummaryManager` methods, providing defense in depth.
+3. **Confirmation dialogs** — Browser `confirm()` dialogs are used for both single and bulk delete. Simple, accessible, and consistent with the vanilla JS approach of the admin panel.
+4. **No new dependencies** — Uses only `fs.unlinkSync` and `fs.readdirSync` from Node.js `fs` module, already imported in `call-summary.js`.
+5. **Optimistic UI removal** — On single delete, the table row is removed from the DOM immediately after a successful API response, avoiding a full page reload. On delete-all, the call list is reloaded to reflect the empty state.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Admin as Admin Browser
+    participant Server as Express Server
+    participant CSM as CallSummaryManager
+    participant FS as File System
+
+    Note over Admin,FS: Delete Single Call Log
+    Admin->>Server: DELETE /admin/api/calls/:id
+    Server->>CSM: deleteSummaryById(id)
+    CSM->>CSM: sanitize id with path.basename()
+    CSM->>FS: fs.unlinkSync(filepath)
+    CSM-->>Server: true/false
+    Server-->>Admin: 200 { success: true } or 404
+
+    Note over Admin,FS: Delete All Call Logs
+    Admin->>Server: DELETE /admin/api/calls
+    Server->>CSM: deleteAllSummaries()
+    CSM->>FS: fs.readdirSync + fs.unlinkSync each .json
+    CSM-->>Server: { deletedCount: N }
+    Server-->>Admin: 200 { success: true, deletedCount: N }
+```
+
+## Components and Interfaces
+
+### 1. `src/call-summary.js` — New Deletion Methods
+
+Add two methods to the existing `CallSummaryManager` class:
+
+```js
+/**
+ * Delete a single call summary by ID
+ * @param {string} id - Call summary ID (filename without .json)
+ * @returns {boolean} true if deleted, false if not found
+ */
+deleteSummaryById(id) {
+  const sanitizedId = path.basename(id);
+  const filename = sanitizedId.endsWith('.json') ? sanitizedId : `${sanitizedId}.json`;
+  const filepath = path.join(this.summariesDir, filename);
+
+  if (!fs.existsSync(filepath)) {
+    return false;
+  }
+
+  fs.unlinkSync(filepath);
+  return true;
+}
+
+/**
+ * Delete all call summary JSON files
+ * @returns {number} count of deleted files
+ */
+deleteAllSummaries() {
+  const files = fs.readdirSync(this.summariesDir)
+    .filter(file => file.endsWith('.json'));
+
+  for (const file of files) {
+    fs.unlinkSync(path.join(this.summariesDir, file));
+  }
+
+  return files.length;
+}
+```
+
+### 2. `src/server.js` — New API Endpoints
+
+Two new routes registered in the admin API section, protected by the existing auth and IP whitelist middleware:
+
+```js
+// DELETE /admin/api/calls/:id — Delete a single call log
+app.delete('/admin/api/calls/:id', (req, res) => { ... });
+
+// DELETE /admin/api/calls — Delete all call logs
+app.delete('/admin/api/calls', (req, res) => { ... });
+```
+
+The single-delete handler sanitizes `req.params.id` with `path.basename()` before passing to `deleteSummaryById`. Returns 200 on success, 404 if not found, 500 on unexpected error.
+
+The delete-all handler calls `deleteAllSummaries()` and returns the count. Returns 200 with `{ deletedCount }` on success (including 0), 500 on error.
+
+### 3. `public/admin/calls.html` — UI Changes
+
+- Add a **"Delete All"** button (`.btn-danger`) in the card header next to the "Call History" heading.
+- Add a **delete button** (🗑️ icon or text) in each table row's Actions column.
+- Both buttons trigger `confirm()` dialogs before sending requests.
+- Single delete: calls `DELETE /admin/api/calls/:id`, removes the row from DOM, shows success toast.
+- Delete all: calls `DELETE /admin/api/calls`, shows success toast with count, reloads the call list.
+- The "Delete All" button is disabled while the request is in flight to prevent duplicate submissions.
+
+## Data Models
+
+### API Request/Response
+
+**DELETE /admin/api/calls/:id**
+
+| Field | Value |
+|-------|-------|
+| Method | `DELETE` |
+| URL | `/admin/api/calls/:id` |
+| Auth | Existing admin session cookie |
+| Success Response | `200 { success: true, message: "Call log deleted" }` |
+| Not Found | `404 { error: "Call log not found" }` |
+| Error | `500 { error: "Failed to delete call log", details: "..." }` |
+
+**DELETE /admin/api/calls**
+
+| Field | Value |
+|-------|-------|
+| Method | `DELETE` |
+| URL | `/admin/api/calls` |
+| Auth | Existing admin session cookie |
+| Success Response | `200 { success: true, deletedCount: N }` |
+| Error | `500 { error: "Failed to delete call logs", details: "..." }` |
+
+### Existing Call Summary JSON Structure (unchanged)
+
+```json
+{
+  "callSid": "CA9a4c2121...",
+  "callerPhone": "+1234567890",
+  "twilioNumber": "+0987654321",
+  "startTime": "2026-02-14T22:18:42.308Z",
+  "endTime": "2026-02-14T22:20:15.366Z",
+  "duration": "93 seconds",
+  "summary": "...",
+  "fullTranscript": [
+    { "speaker": "AI Receptionist", "message": "..." },
+    { "speaker": "Caller", "message": "..." }
+  ]
+}
+```
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Delete single existing call log
+
+*For any* call summary JSON file that exists in the `call-summaries/` directory, calling `deleteSummaryById` with its ID should delete the file from disk and return `true`. After deletion, the file should no longer exist.
+
+**Validates: Requirements 1.3, 3.1, 3.4**
+
+### Property 2: Delete non-existent call log returns false
+
+*For any* string ID that does not correspond to an existing JSON file in the `call-summaries/` directory, calling `deleteSummaryById` should return `false` and leave the directory contents unchanged.
+
+**Validates: Requirements 1.5, 3.3**
+
+### Property 3: Path traversal sanitization
+
+*For any* string input containing path separators or directory traversal sequences (e.g., `../`, `/etc/passwd`), `deleteSummaryById` should resolve the file path to within the `call-summaries/` directory only. The sanitized path should never reference a file outside that directory.
+
+**Validates: Requirements 1.7, 3.5**
+
+### Property 4: Delete all removes all JSON files and returns correct count
+
+*For any* set of N JSON files in the `call-summaries/` directory, calling `deleteAllSummaries` should delete all N files and return N. After the operation, zero JSON files should remain in the directory.
+
+**Validates: Requirements 2.3, 3.2**
+
+### Property 5: Delete all preserves non-JSON files
+
+*For any* `call-summaries/` directory containing a mix of `.json` and non-`.json` files, calling `deleteAllSummaries` should only remove files with the `.json` extension. All non-JSON files should remain untouched.
+
+**Validates: Requirements 2.7**
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Delete single — file not found | `deleteSummaryById` returns `false`; API returns 404 `{ error: "Call log not found" }` |
+| Delete single — fs error (permissions, etc.) | `deleteSummaryById` throws; API catches and returns 500 `{ error: "Failed to delete call log", details: "..." }` |
+| Delete all — empty directory | `deleteAllSummaries` returns `0`; API returns 200 `{ success: true, deletedCount: 0 }` |
+| Delete all — partial failure (some files fail to delete) | Exception thrown mid-loop; API catches and returns 500. Some files may already be deleted. |
+| Path traversal attempt in ID | `path.basename()` strips directory components; resolved path stays within `call-summaries/`. If sanitized filename doesn't exist, returns 404. |
+| Unauthenticated request | Existing auth middleware returns 401 (API) or redirects to login (page). Delete handlers never reached. |
+| Malformed ID (empty string, special chars) | `path.basename()` handles gracefully; if resulting filename doesn't match a file, returns false/404. |
+
+## Testing Strategy
+
+### Unit Tests (vitest)
+
+Unit tests cover specific examples, edge cases, and integration points:
+
+- Delete button is present in each call log row HTML
+- "Delete All" button is present in the card header
+- `DELETE /admin/api/calls/:id` returns 404 for non-existent ID
+- `DELETE /admin/api/calls/:id` returns 200 for existing ID
+- `DELETE /admin/api/calls` returns 200 with `deletedCount: 0` for empty directory
+- `DELETE /admin/api/calls` requires authentication (returns 401 without session)
+- `DELETE /admin/api/calls/:id` requires authentication (returns 401 without session)
+
+Test file: `tests/unit/call-log-deletion.test.js`
+
+### Property-Based Tests (vitest + fast-check)
+
+Each correctness property maps to a single property-based test. Tests use `fast-check` for input generation with a minimum of 100 iterations.
+
+| Test File | Property | Tag |
+|-----------|----------|-----|
+| `tests/property/call-log-deletion.property.test.js` | Property 1 | Feature: call-log-deletion, Property 1: Delete single existing call log |
+| `tests/property/call-log-deletion.property.test.js` | Property 2 | Feature: call-log-deletion, Property 2: Delete non-existent call log returns false |
+| `tests/property/call-log-deletion.property.test.js` | Property 3 | Feature: call-log-deletion, Property 3: Path traversal sanitization |
+| `tests/property/call-log-deletion.property.test.js` | Property 4 | Feature: call-log-deletion, Property 4: Delete all removes all JSON files and returns correct count |
+| `tests/property/call-log-deletion.property.test.js` | Property 5 | Feature: call-log-deletion, Property 5: Delete all preserves non-JSON files |
+
+**PBT Library:** `fast-check` (already installed)
+
+**Test Runner:** `vitest --run`
+
+**Generators needed:**
+- `fc.string()` / `fc.stringMatching(...)` — for call log IDs, filenames
+- `fc.nat()` — for generating N files to populate a temp directory
+- `fc.array(fc.string())` — for generating sets of filenames
+- `fc.constantFrom('.json', '.txt', '.log', '.md')` — for file extension mixing
+
+Each property test must be tagged with a comment in the format:
+```
+// Feature: call-log-deletion, Property N: <property title>
+```
+
+Each property test must run a minimum of 100 iterations (`{ numRuns: 100 }`).

--- a/.kiro/specs/call-log-deletion/requirements.md
+++ b/.kiro/specs/call-log-deletion/requirements.md
@@ -1,0 +1,58 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds call log deletion capabilities to the admin panel of the AI Phone Receptionist. Administrators need the ability to delete individual call logs or all call logs at once from the admin dashboard. Call summaries are stored as JSON files in the `call-summaries/` directory and are currently view-only through the admin panel at `public/admin/calls.html`.
+
+## Glossary
+
+- **Admin_Panel**: The web-based administration dashboard served at `/admin/`, used by practice administrators to manage the AI Phone Receptionist system.
+- **Call_Log**: A JSON file stored in the `call-summaries/` directory containing call metadata, AI-generated summary, and full transcript for a single phone call.
+- **Call_Logs_Page**: The admin panel page at `/admin/calls.html` that displays paginated call history with details.
+- **Server**: The Express.js backend (`src/server.js`) that serves admin API endpoints under `/admin/api/`.
+- **Call_Summary_Manager**: The module (`src/call-summary.js`) responsible for reading, writing, and managing call summary JSON files.
+
+## Requirements
+
+### Requirement 1: Delete a Single Call Log
+
+**User Story:** As a practice administrator, I want to delete a specific call log from the call logs page, so that I can remove outdated or irrelevant call records individually.
+
+#### Acceptance Criteria
+
+1. THE Call_Logs_Page SHALL display a delete button for each call log entry in the call history table.
+2. WHEN the administrator clicks the delete button for a specific call log, THE Call_Logs_Page SHALL display a confirmation dialog asking the administrator to confirm the deletion.
+3. WHEN the administrator confirms the deletion, THE Call_Logs_Page SHALL send a delete request to the Server, and the Server SHALL remove the matching Call_Log file from the `call-summaries/` directory.
+4. WHEN the Server successfully deletes the Call_Log, THE Call_Logs_Page SHALL remove the corresponding row from the table and display a success toast notification.
+5. IF the specified Call_Log does not exist, THEN THE Server SHALL return an error response with HTTP status 404, and THE Call_Logs_Page SHALL display an error toast notification.
+6. IF an unexpected error occurs during deletion, THEN THE Server SHALL return an error response with HTTP status 500, and THE Call_Logs_Page SHALL display an error toast notification with the error message.
+7. THE Server SHALL sanitize the call log ID parameter using `path.basename` to prevent directory traversal attacks before performing any file system operation.
+8. THE Server SHALL require the request to pass through the existing admin authentication middleware before processing the deletion.
+
+### Requirement 2: Delete All Call Logs
+
+**User Story:** As a practice administrator, I want to delete all call logs at once from the call logs page, so that I can clear the entire call history efficiently without removing records one by one.
+
+#### Acceptance Criteria
+
+1. THE Call_Logs_Page SHALL display a "Delete All" button in the call history card header area, styled as a danger button.
+2. WHEN the administrator clicks the "Delete All" button, THE Call_Logs_Page SHALL display a confirmation dialog warning that all call logs will be permanently deleted.
+3. WHEN the administrator confirms the deletion, THE Call_Logs_Page SHALL send a delete request to the Server, and the Server SHALL remove all Call_Log JSON files from the `call-summaries/` directory.
+4. WHEN the Server successfully deletes all Call_Logs, THE Call_Logs_Page SHALL display a success toast notification showing the count of deleted call logs and reload the call list.
+5. IF the `call-summaries/` directory contains no Call_Log files, THEN THE Server SHALL return a success response with a count of zero deleted files.
+6. IF an error occurs while deleting Call_Log files, THEN THE Server SHALL return an error response with HTTP status 500, and THE Call_Logs_Page SHALL display an error toast notification with the error message.
+7. THE Server SHALL only delete files with the `.json` extension from the `call-summaries/` directory during a delete-all operation.
+8. WHILE the delete-all operation is in progress, THE Call_Logs_Page SHALL disable the "Delete All" button to prevent duplicate requests.
+9. THE Server SHALL require the request to pass through the existing admin authentication middleware before processing the deletion.
+
+### Requirement 3: Call Summary Manager Deletion Support
+
+**User Story:** As a developer, I want the Call_Summary_Manager to support deletion operations, so that the Server can reliably delete call log files through a consistent interface.
+
+#### Acceptance Criteria
+
+1. THE Call_Summary_Manager SHALL provide a `deleteSummaryById` method that accepts a call log ID and deletes the corresponding JSON file from the `call-summaries/` directory.
+2. THE Call_Summary_Manager SHALL provide a `deleteAllSummaries` method that deletes all JSON files from the `call-summaries/` directory and returns the count of deleted files.
+3. WHEN `deleteSummaryById` is called with an ID that does not match any file, THE Call_Summary_Manager SHALL return `false`.
+4. WHEN `deleteSummaryById` is called with a valid ID, THE Call_Summary_Manager SHALL delete the file and return `true`.
+5. THE Call_Summary_Manager SHALL sanitize all ID parameters using `path.basename` to prevent directory traversal before performing file operations.

--- a/.kiro/specs/call-log-deletion/tasks.md
+++ b/.kiro/specs/call-log-deletion/tasks.md
@@ -1,0 +1,92 @@
+# Implementation Plan: Call Log Deletion
+
+## Overview
+
+Add delete single and delete all capabilities to the call logs page in the admin panel. Two new methods on `CallSummaryManager`, two new DELETE endpoints on the Express server, and UI controls on `calls.html`. No new dependencies needed.
+
+## Tasks
+
+- [x] 0. Create feature branch
+  - [x] 0.1 Create and switch to a new git branch `feature/call-log-deletion` from the current branch
+
+- [x] 1. Add deletion methods to CallSummaryManager
+  - [x] 1.1 Add `deleteSummaryById(id)` method to `src/call-summary.js`
+    - Sanitize `id` with `path.basename()` to prevent directory traversal
+    - Append `.json` if not already present
+    - Return `true` if file existed and was deleted, `false` if not found
+    - Use `fs.unlinkSync` for deletion
+    - _Requirements: 3.1, 3.3, 3.4, 3.5_
+
+  - [x] 1.2 Add `deleteAllSummaries()` method to `src/call-summary.js`
+    - Read directory, filter to `.json` files only
+    - Delete each `.json` file with `fs.unlinkSync`
+    - Return count of deleted files (0 if directory was empty)
+    - _Requirements: 3.2, 2.5, 2.7_
+
+  - [ ]* 1.3 Write property test for single delete (Property 1)
+    - **Property 1: Delete single existing call log**
+    - For any existing call summary file, `deleteSummaryById` removes it and returns `true`
+    - Use temp directory with generated JSON files
+    - **Validates: Requirements 1.3, 3.1, 3.4**
+
+  - [ ]* 1.4 Write property test for non-existent delete (Property 2)
+    - **Property 2: Delete non-existent call log returns false**
+    - For any ID not matching an existing file, `deleteSummaryById` returns `false` and directory is unchanged
+    - **Validates: Requirements 1.5, 3.3**
+
+  - [ ]* 1.5 Write property test for path traversal sanitization (Property 3)
+    - **Property 3: Path traversal sanitization**
+    - For any string with path separators or `../`, the resolved path stays within `call-summaries/`
+    - **Validates: Requirements 1.7, 3.5**
+
+  - [ ]* 1.6 Write property test for delete all (Property 4)
+    - **Property 4: Delete all removes all JSON files and returns correct count**
+    - For any directory with N JSON files, `deleteAllSummaries` returns N and zero JSON files remain
+    - **Validates: Requirements 2.3, 3.2**
+
+  - [ ]* 1.7 Write property test for non-JSON preservation (Property 5)
+    - **Property 5: Delete all preserves non-JSON files**
+    - For any directory with mixed file types, only `.json` files are removed
+    - **Validates: Requirements 2.7**
+
+- [x] 2. Add DELETE API endpoints to server
+  - [x] 2.1 Add `DELETE /admin/api/calls/:id` endpoint to `src/server.js`
+    - Sanitize `req.params.id` with `path.basename()` (defense in depth)
+    - Call `callSummaryManager.deleteSummaryById(id)`
+    - Return 200 on success, 404 if not found, 500 on error
+    - Log deletion with error buffer on failure
+    - _Requirements: 1.3, 1.5, 1.6, 1.7, 1.8_
+
+  - [x] 2.2 Add `DELETE /admin/api/calls` endpoint to `src/server.js`
+    - Call `callSummaryManager.deleteAllSummaries()`
+    - Return 200 with `{ success: true, deletedCount: N }`
+    - Return 500 on error
+    - Log deletion with error buffer on failure
+    - _Requirements: 2.3, 2.5, 2.6, 2.9_
+
+- [x] 3. Add deletion UI to calls page
+  - [x] 3.1 Add "Delete All" button and per-row delete buttons to `public/admin/calls.html`
+    - Add "Delete All" button (`.btn-danger`) in the card header next to "Call History" heading
+    - Add delete button (🗑️) in each table row's Actions column
+    - Single delete: `confirm()` dialog, then `DELETE /admin/api/calls/:id`, remove row from DOM, show success toast
+    - Delete all: `confirm()` dialog, then `DELETE /admin/api/calls`, show success toast with count, reload call list
+    - Disable "Delete All" button while request is in flight
+    - _Requirements: 1.1, 1.2, 1.4, 2.1, 2.2, 2.4, 2.8_
+
+- [ ] 4. Write unit tests for API endpoints
+  - [ ]* 4.1 Write unit tests in `tests/unit/call-log-deletion.test.js`
+    - `DELETE /admin/api/calls/:id` returns 404 for non-existent ID
+    - `DELETE /admin/api/calls/:id` returns 200 for existing ID
+    - `DELETE /admin/api/calls` returns 200 with `deletedCount: 0` for empty directory
+    - `DELETE /admin/api/calls/:id` returns 401 without auth session
+    - `DELETE /admin/api/calls` returns 401 without auth session
+    - _Requirements: 1.5, 1.6, 1.8, 2.5, 2.6, 2.9_
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Property tests use `fast-check` with minimum 100 iterations per property
+- All property tests go in `tests/property/call-log-deletion.property.test.js`
+- Unit tests go in `tests/unit/call-log-deletion.test.js`
+- No new npm dependencies needed

--- a/public/admin/calls.html
+++ b/public/admin/calls.html
@@ -21,7 +21,10 @@
 
   <div class="container">
     <div class="card">
-      <h2>Call History</h2>
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+        <h2 style="margin-bottom: 0;">Call History</h2>
+        <button id="deleteAllBtn" class="btn btn-danger btn-sm" onclick="deleteAllCalls()">🗑️ Delete All</button>
+      </div>
       <div id="callsContainer">
         <div class="spinner"></div>
       </div>
@@ -82,6 +85,7 @@
                     <span class="expand-toggle" onclick="toggleTranscript('${UI.escapeHtml(call.id)}')">
                       View Details
                     </span>
+                    <button class="btn btn-danger btn-sm" style="margin-left: 0.5rem; padding: 0.25rem 0.5rem; font-size: 0.8rem;" onclick="deleteSingleCall('${UI.escapeHtml(call.id)}', this)" title="Delete this call log">🗑️</button>
                   </td>
                 </tr>
                 <tr id="transcript-${UI.escapeHtml(call.id)}" class="hidden">
@@ -186,9 +190,57 @@
       pagination.innerHTML = buttons.join('');
     }
 
+    // Delete a single call log
+    async function deleteSingleCall(callId, buttonEl) {
+      if (!confirm('Are you sure you want to delete this call log? This action cannot be undone.')) {
+        return;
+      }
+
+      try {
+        await UI.apiFetch(`/admin/api/calls/${encodeURIComponent(callId)}`, { method: 'DELETE' });
+
+        // Remove the call row and its transcript row from the DOM
+        const transcriptRow = document.getElementById(`transcript-${callId}`);
+        if (transcriptRow) {
+          transcriptRow.previousElementSibling.remove();
+          transcriptRow.remove();
+        } else {
+          // Fallback: walk up from the button to the <tr>
+          const row = buttonEl.closest('tr');
+          if (row) row.remove();
+        }
+
+        UI.Toast.success('Call log deleted successfully');
+      } catch (error) {
+        UI.Toast.error('Failed to delete call log: ' + error.message);
+      }
+    }
+
+    // Delete all call logs
+    async function deleteAllCalls() {
+      if (!confirm('Are you sure you want to delete ALL call logs? This action cannot be undone.')) {
+        return;
+      }
+
+      const deleteAllBtn = document.getElementById('deleteAllBtn');
+      deleteAllBtn.disabled = true;
+
+      try {
+        const data = await UI.apiFetch('/admin/api/calls', { method: 'DELETE' });
+        UI.Toast.success(`Deleted ${data.deletedCount} call log(s)`);
+        loadCalls(1);
+      } catch (error) {
+        UI.Toast.error('Failed to delete call logs: ' + error.message);
+      } finally {
+        deleteAllBtn.disabled = false;
+      }
+    }
+
     // Make functions available globally
     window.toggleTranscript = toggleTranscript;
     window.loadCalls = loadCalls;
+    window.deleteSingleCall = deleteSingleCall;
+    window.deleteAllCalls = deleteAllCalls;
 
     // Load calls on page load
     loadCalls(1);

--- a/public/embed-chat.html
+++ b/public/embed-chat.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chat with us</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      background: transparent;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .chat-header {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 16px 20px;
+    }
+
+    .chat-header h1 {
+      font-size: 18px;
+      margin-bottom: 2px;
+    }
+
+    .chat-header p {
+      font-size: 13px;
+      opacity: 0.9;
+    }
+
+    .chat-messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 20px;
+      background: #f7f7f7;
+    }
+
+    .message {
+      margin-bottom: 15px;
+      display: flex;
+      align-items: flex-start;
+    }
+
+    .message.user {
+      justify-content: flex-end;
+    }
+
+    .message-content {
+      max-width: 80%;
+      padding: 12px 16px;
+      border-radius: 18px;
+      line-height: 1.4;
+      font-size: 14px;
+    }
+
+    .message.ai .message-content {
+      background: white;
+      color: #333;
+      border-bottom-left-radius: 4px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+
+    .message.user .message-content {
+      background: #667eea;
+      color: white;
+      border-bottom-right-radius: 4px;
+    }
+
+    .chat-input-container {
+      padding: 14px 16px;
+      background: white;
+      border-top: 1px solid #e0e0e0;
+    }
+
+    .chat-input-form {
+      display: flex;
+      gap: 8px;
+    }
+
+    .chat-input {
+      flex: 1;
+      padding: 10px 16px;
+      border: 2px solid #e0e0e0;
+      border-radius: 24px;
+      font-size: 14px;
+      outline: none;
+      transition: border-color 0.3s;
+    }
+
+    .chat-input:focus {
+      border-color: #667eea;
+    }
+
+    .chat-send-btn {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 24px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.2s;
+    }
+
+    .chat-send-btn:hover {
+      opacity: 0.9;
+    }
+
+    .chat-send-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .typing-indicator {
+      display: none;
+      padding: 12px 16px;
+      background: white;
+      border-radius: 18px;
+      border-bottom-left-radius: 4px;
+      max-width: 70px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+
+    .typing-indicator.active {
+      display: block;
+    }
+
+    .typing-indicator span {
+      height: 8px;
+      width: 8px;
+      background: #999;
+      border-radius: 50%;
+      display: inline-block;
+      margin-right: 4px;
+      animation: typing 1.4s infinite;
+    }
+
+    .typing-indicator span:nth-child(2) { animation-delay: 0.2s; }
+    .typing-indicator span:nth-child(3) { animation-delay: 0.4s; }
+
+    @keyframes typing {
+      0%, 60%, 100% { transform: translateY(0); }
+      30% { transform: translateY(-8px); }
+    }
+  </style>
+</head>
+<body>
+  <div class="chat-header">
+    <h1>Chat with us</h1>
+    <p>Relational Therapy Collective</p>
+  </div>
+
+  <div class="chat-messages" id="messages"></div>
+
+  <div class="chat-input-container">
+    <form class="chat-input-form" id="chatForm">
+      <input
+        type="text"
+        class="chat-input"
+        id="messageInput"
+        placeholder="Type your message..."
+        autocomplete="off"
+      >
+      <button type="submit" class="chat-send-btn" id="sendBtn">Send</button>
+    </form>
+  </div>
+
+  <script>
+    const messagesContainer = document.getElementById('messages');
+    const chatForm = document.getElementById('chatForm');
+    const messageInput = document.getElementById('messageInput');
+    const sendBtn = document.getElementById('sendBtn');
+
+    // Determine API base URL (same origin as this page)
+    const API_BASE = window.location.origin;
+
+    // Session and conversation state
+    let sessionId = 'embed-' + crypto.randomUUID();
+    let conversationHistory = [];
+
+    // Load greeting on page load
+    async function loadGreeting() {
+      try {
+        const response = await fetch(API_BASE + '/api/greeting');
+        const data = await response.json();
+        addMessage('ai', data.greeting);
+      } catch (error) {
+        addMessage('ai', 'Hello! How can I help you today?');
+      }
+    }
+
+    loadGreeting();
+
+    chatForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const message = messageInput.value.trim();
+      if (!message) return;
+
+      addMessage('user', message);
+      messageInput.value = '';
+
+      // Add to conversation history
+      conversationHistory.push({ role: 'user', content: message });
+
+      const typingIndicator = addTypingIndicator();
+      messageInput.disabled = true;
+      sendBtn.disabled = true;
+
+      try {
+        const response = await fetch(API_BASE + '/api/webchat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId: sessionId,
+            messages: conversationHistory
+          })
+        });
+
+        const data = await response.json();
+        typingIndicator.remove();
+
+        // Add AI response to history and display
+        conversationHistory.push({ role: 'assistant', content: data.response });
+        addMessage('ai', data.response);
+
+      } catch (error) {
+        typingIndicator.remove();
+        addMessage('ai', 'Sorry, I encountered an error. Please try again.');
+      }
+
+      messageInput.disabled = false;
+      sendBtn.disabled = false;
+      messageInput.focus();
+    });
+
+    function addMessage(type, content) {
+      const messageDiv = document.createElement('div');
+      messageDiv.className = 'message ' + type;
+
+      const bubble = document.createElement('div');
+      bubble.className = 'message-content';
+      bubble.textContent = content;
+
+      messageDiv.appendChild(bubble);
+      messagesContainer.appendChild(messageDiv);
+      messagesContainer.scrollTop = messagesContainer.scrollHeight;
+    }
+
+    function addTypingIndicator() {
+      const typingDiv = document.createElement('div');
+      typingDiv.className = 'message ai';
+      typingDiv.innerHTML = '<div class="typing-indicator active"><span></span><span></span><span></span></div>';
+      messagesContainer.appendChild(typingDiv);
+      messagesContainer.scrollTop = messagesContainer.scrollHeight;
+      return typingDiv;
+    }
+
+    messageInput.focus();
+  </script>
+</body>
+</html>

--- a/src/call-summary.js
+++ b/src/call-summary.js
@@ -226,6 +226,40 @@ ${messages.map(m => `${m.role === 'user' ? 'Caller' : 'Receptionist'}: ${m.conte
       return null;
     }
   }
+
+  /**
+   * Delete a single call summary by ID
+   * @param {string} id - Call summary ID (filename without .json)
+   * @returns {boolean} true if deleted, false if not found
+   */
+  deleteSummaryById(id) {
+    const sanitizedId = path.basename(id);
+    const filename = sanitizedId.endsWith('.json') ? sanitizedId : `${sanitizedId}.json`;
+    const filepath = path.join(this.summariesDir, filename);
+
+    if (!fs.existsSync(filepath)) {
+      return false;
+    }
+
+    fs.unlinkSync(filepath);
+    return true;
+  }
+
+  /**
+   * Delete all call summary JSON files
+   * @returns {number} count of deleted files
+   */
+  deleteAllSummaries() {
+    const files = fs.readdirSync(this.summariesDir)
+      .filter(file => file.endsWith('.json'));
+
+    for (const file of files) {
+      fs.unlinkSync(path.join(this.summariesDir, file));
+    }
+
+    return files.length;
+  }
+
 }
 
 module.exports = new CallSummaryManager();

--- a/src/server.js
+++ b/src/server.js
@@ -475,6 +475,41 @@ app.get('/admin/api/calls/:id', (req, res) => {
   }
 });
 
+// Admin delete all call logs endpoint
+app.delete('/admin/api/calls', (req, res) => {
+  try {
+    const callSummaryManager = require('./call-summary');
+    const deletedCount = callSummaryManager.deleteAllSummaries();
+
+    console.log(`🗑️ All call logs deleted: ${deletedCount} files removed`);
+    res.json({ success: true, deletedCount });
+  } catch (error) {
+    console.error('❌ Error deleting all call logs:', error);
+    errorBuffer.add(error, 'admin-calls-delete-all-api');
+    res.status(500).json({ error: 'Failed to delete call logs', details: error.message });
+  }
+});
+
+// Admin delete single call log endpoint
+app.delete('/admin/api/calls/:id', (req, res) => {
+  try {
+    const id = path.basename(req.params.id);
+    const callSummaryManager = require('./call-summary');
+    const deleted = callSummaryManager.deleteSummaryById(id);
+
+    if (!deleted) {
+      return res.status(404).json({ error: 'Call log not found' });
+    }
+
+    console.log(`🗑️ Call log deleted: ${id}`);
+    res.json({ success: true, message: 'Call log deleted' });
+  } catch (error) {
+    console.error('❌ Error deleting call log:', error);
+    errorBuffer.add(error, 'admin-call-delete-api');
+    res.status(500).json({ error: 'Failed to delete call log', details: error.message });
+  }
+});
+
 // Admin availability list endpoint
 app.get('/admin/api/availability', (req, res) => {
   try {


### PR DESCRIPTION
Adds delete single and delete all capabilities to the call logs page in the admin panel.

Changes:

- deleteSummaryById(id) and deleteAllSummaries() methods on CallSummaryManager with path traversal sanitization
- DELETE /admin/api/calls/:id and DELETE /admin/api/calls endpoints behind existing auth middleware
- "Delete All" button and per-row 🗑️ delete buttons on calls.html with confirmation dialogs and toast notifications

Also
Web chat embedded in a webpage for sites that don't have code injection. Created embed-chat.html