### PR TITLE
Merge chargewizards + post-call-agents into main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
+BUSINESS_NAME=RTC Bellevue
+OWNER_NAME=Miri Arie
+RECEPTIONIST_NAME=Sunny
+OWNER_PHONE=+1234567890
+PUBLIC_URL=https://www.rtcbellevue.com
+
 # Twilio Configuration
 TWILIO_ACCOUNT_SID=your_account_sid_here
 TWILIO_AUTH_TOKEN=your_auth_token_here
@@ -84,3 +90,26 @@ RETRY_DELAY=1000                 # Initial retry delay in milliseconds
 # Benefits: detailed insurance info, better accuracy, per-provider caching
 # Performance: ~40-90 seconds for 10 providers (vs ~30-60 seconds single-page)
 MULTI_PAGE_SCRAPING=true
+
+# Email Notification (SMTP) Configuration
+# Required for post-call provider notifications and daily digest emails
+SMTP_HOST=smtp.example.com
+SMTP_PORT=465
+SMTP_USER=your_smtp_user
+SMTP_PASS=your_smtp_password
+SMTP_FROM=receptionist@yourpractice.com
+
+# Admin email for daily digest reports
+ADMIN_EMAIL=admin@yourpractice.com
+
+# Set DIGEST_ENABLED to true in order to use. Note: it was not tested yet
+# Hour (0-23) to send the daily digest email (default: 18 = 6 PM)
+DIGEST_ENABLED=false  
+DIGEST_SCHEDULE_HOUR=18
+
+
+# Post-Call Agent Mode
+# shadow  — run agent in parallel with existing flow, save to shadow files (default)
+# active  — agent replaces existing flow (with fallback)
+# disabled — existing flow only, no agent
+POST_CALL_AGENT_MODE=shadow

--- a/.kiro/specs/call-log-deletion/.config.kiro
+++ b/.kiro/specs/call-log-deletion/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "d2426921-f8b6-4ce6-86bd-5c9e2f8fb3a6", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/call-log-deletion/design.md
+++ b/.kiro/specs/call-log-deletion/design.md
@@ -1,0 +1,239 @@
+# Design Document: Call Log Deletion
+
+## Overview
+
+This feature adds delete capabilities to the call logs page in the admin panel. Administrators can delete a single call log or all call logs at once. Call summaries are JSON files stored in `call-summaries/`. The implementation adds two new methods to `CallSummaryManager` (`deleteSummaryById`, `deleteAllSummaries`), two new Express DELETE endpoints, and UI controls (per-row delete button, "Delete All" button with confirmation dialogs) on the existing `calls.html` page.
+
+### Key Design Decisions
+
+1. **DELETE HTTP methods** — Uses `DELETE /admin/api/calls/:id` and `DELETE /admin/api/calls` to follow REST conventions. Both routes sit behind the existing IP whitelist and auth middleware, so no new auth logic is needed.
+2. **Path traversal prevention** — All ID parameters are sanitized with `path.basename()` in both the server route handler and the `CallSummaryManager` methods, providing defense in depth.
+3. **Confirmation dialogs** — Browser `confirm()` dialogs are used for both single and bulk delete. Simple, accessible, and consistent with the vanilla JS approach of the admin panel.
+4. **No new dependencies** — Uses only `fs.unlinkSync` and `fs.readdirSync` from Node.js `fs` module, already imported in `call-summary.js`.
+5. **Optimistic UI removal** — On single delete, the table row is removed from the DOM immediately after a successful API response, avoiding a full page reload. On delete-all, the call list is reloaded to reflect the empty state.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Admin as Admin Browser
+    participant Server as Express Server
+    participant CSM as CallSummaryManager
+    participant FS as File System
+
+    Note over Admin,FS: Delete Single Call Log
+    Admin->>Server: DELETE /admin/api/calls/:id
+    Server->>CSM: deleteSummaryById(id)
+    CSM->>CSM: sanitize id with path.basename()
+    CSM->>FS: fs.unlinkSync(filepath)
+    CSM-->>Server: true/false
+    Server-->>Admin: 200 { success: true } or 404
+
+    Note over Admin,FS: Delete All Call Logs
+    Admin->>Server: DELETE /admin/api/calls
+    Server->>CSM: deleteAllSummaries()
+    CSM->>FS: fs.readdirSync + fs.unlinkSync each .json
+    CSM-->>Server: { deletedCount: N }
+    Server-->>Admin: 200 { success: true, deletedCount: N }
+```
+
+## Components and Interfaces
+
+### 1. `src/call-summary.js` — New Deletion Methods
+
+Add two methods to the existing `CallSummaryManager` class:
+
+```js
+/**
+ * Delete a single call summary by ID
+ * @param {string} id - Call summary ID (filename without .json)
+ * @returns {boolean} true if deleted, false if not found
+ */
+deleteSummaryById(id) {
+  const sanitizedId = path.basename(id);
+  const filename = sanitizedId.endsWith('.json') ? sanitizedId : `${sanitizedId}.json`;
+  const filepath = path.join(this.summariesDir, filename);
+
+  if (!fs.existsSync(filepath)) {
+    return false;
+  }
+
+  fs.unlinkSync(filepath);
+  return true;
+}
+
+/**
+ * Delete all call summary JSON files
+ * @returns {number} count of deleted files
+ */
+deleteAllSummaries() {
+  const files = fs.readdirSync(this.summariesDir)
+    .filter(file => file.endsWith('.json'));
+
+  for (const file of files) {
+    fs.unlinkSync(path.join(this.summariesDir, file));
+  }
+
+  return files.length;
+}
+```
+
+### 2. `src/server.js` — New API Endpoints
+
+Two new routes registered in the admin API section, protected by the existing auth and IP whitelist middleware:
+
+```js
+// DELETE /admin/api/calls/:id — Delete a single call log
+app.delete('/admin/api/calls/:id', (req, res) => { ... });
+
+// DELETE /admin/api/calls — Delete all call logs
+app.delete('/admin/api/calls', (req, res) => { ... });
+```
+
+The single-delete handler sanitizes `req.params.id` with `path.basename()` before passing to `deleteSummaryById`. Returns 200 on success, 404 if not found, 500 on unexpected error.
+
+The delete-all handler calls `deleteAllSummaries()` and returns the count. Returns 200 with `{ deletedCount }` on success (including 0), 500 on error.
+
+### 3. `public/admin/calls.html` — UI Changes
+
+- Add a **"Delete All"** button (`.btn-danger`) in the card header next to the "Call History" heading.
+- Add a **delete button** (🗑️ icon or text) in each table row's Actions column.
+- Both buttons trigger `confirm()` dialogs before sending requests.
+- Single delete: calls `DELETE /admin/api/calls/:id`, removes the row from DOM, shows success toast.
+- Delete all: calls `DELETE /admin/api/calls`, shows success toast with count, reloads the call list.
+- The "Delete All" button is disabled while the request is in flight to prevent duplicate submissions.
+
+## Data Models
+
+### API Request/Response
+
+**DELETE /admin/api/calls/:id**
+
+| Field | Value |
+|-------|-------|
+| Method | `DELETE` |
+| URL | `/admin/api/calls/:id` |
+| Auth | Existing admin session cookie |
+| Success Response | `200 { success: true, message: "Call log deleted" }` |
+| Not Found | `404 { error: "Call log not found" }` |
+| Error | `500 { error: "Failed to delete call log", details: "..." }` |
+
+**DELETE /admin/api/calls**
+
+| Field | Value |
+|-------|-------|
+| Method | `DELETE` |
+| URL | `/admin/api/calls` |
+| Auth | Existing admin session cookie |
+| Success Response | `200 { success: true, deletedCount: N }` |
+| Error | `500 { error: "Failed to delete call logs", details: "..." }` |
+
+### Existing Call Summary JSON Structure (unchanged)
+
+```json
+{
+  "callSid": "CA9a4c2121...",
+  "callerPhone": "+1234567890",
+  "twilioNumber": "+0987654321",
+  "startTime": "2026-02-14T22:18:42.308Z",
+  "endTime": "2026-02-14T22:20:15.366Z",
+  "duration": "93 seconds",
+  "summary": "...",
+  "fullTranscript": [
+    { "speaker": "AI Receptionist", "message": "..." },
+    { "speaker": "Caller", "message": "..." }
+  ]
+}
+```
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Delete single existing call log
+
+*For any* call summary JSON file that exists in the `call-summaries/` directory, calling `deleteSummaryById` with its ID should delete the file from disk and return `true`. After deletion, the file should no longer exist.
+
+**Validates: Requirements 1.3, 3.1, 3.4**
+
+### Property 2: Delete non-existent call log returns false
+
+*For any* string ID that does not correspond to an existing JSON file in the `call-summaries/` directory, calling `deleteSummaryById` should return `false` and leave the directory contents unchanged.
+
+**Validates: Requirements 1.5, 3.3**
+
+### Property 3: Path traversal sanitization
+
+*For any* string input containing path separators or directory traversal sequences (e.g., `../`, `/etc/passwd`), `deleteSummaryById` should resolve the file path to within the `call-summaries/` directory only. The sanitized path should never reference a file outside that directory.
+
+**Validates: Requirements 1.7, 3.5**
+
+### Property 4: Delete all removes all JSON files and returns correct count
+
+*For any* set of N JSON files in the `call-summaries/` directory, calling `deleteAllSummaries` should delete all N files and return N. After the operation, zero JSON files should remain in the directory.
+
+**Validates: Requirements 2.3, 3.2**
+
+### Property 5: Delete all preserves non-JSON files
+
+*For any* `call-summaries/` directory containing a mix of `.json` and non-`.json` files, calling `deleteAllSummaries` should only remove files with the `.json` extension. All non-JSON files should remain untouched.
+
+**Validates: Requirements 2.7**
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Delete single — file not found | `deleteSummaryById` returns `false`; API returns 404 `{ error: "Call log not found" }` |
+| Delete single — fs error (permissions, etc.) | `deleteSummaryById` throws; API catches and returns 500 `{ error: "Failed to delete call log", details: "..." }` |
+| Delete all — empty directory | `deleteAllSummaries` returns `0`; API returns 200 `{ success: true, deletedCount: 0 }` |
+| Delete all — partial failure (some files fail to delete) | Exception thrown mid-loop; API catches and returns 500. Some files may already be deleted. |
+| Path traversal attempt in ID | `path.basename()` strips directory components; resolved path stays within `call-summaries/`. If sanitized filename doesn't exist, returns 404. |
+| Unauthenticated request | Existing auth middleware returns 401 (API) or redirects to login (page). Delete handlers never reached. |
+| Malformed ID (empty string, special chars) | `path.basename()` handles gracefully; if resulting filename doesn't match a file, returns false/404. |
+
+## Testing Strategy
+
+### Unit Tests (vitest)
+
+Unit tests cover specific examples, edge cases, and integration points:
+
+- Delete button is present in each call log row HTML
+- "Delete All" button is present in the card header
+- `DELETE /admin/api/calls/:id` returns 404 for non-existent ID
+- `DELETE /admin/api/calls/:id` returns 200 for existing ID
+- `DELETE /admin/api/calls` returns 200 with `deletedCount: 0` for empty directory
+- `DELETE /admin/api/calls` requires authentication (returns 401 without session)
+- `DELETE /admin/api/calls/:id` requires authentication (returns 401 without session)
+
+Test file: `tests/unit/call-log-deletion.test.js`
+
+### Property-Based Tests (vitest + fast-check)
+
+Each correctness property maps to a single property-based test. Tests use `fast-check` for input generation with a minimum of 100 iterations.
+
+| Test File | Property | Tag |
+|-----------|----------|-----|
+| `tests/property/call-log-deletion.property.test.js` | Property 1 | Feature: call-log-deletion, Property 1: Delete single existing call log |
+| `tests/property/call-log-deletion.property.test.js` | Property 2 | Feature: call-log-deletion, Property 2: Delete non-existent call log returns false |
+| `tests/property/call-log-deletion.property.test.js` | Property 3 | Feature: call-log-deletion, Property 3: Path traversal sanitization |
+| `tests/property/call-log-deletion.property.test.js` | Property 4 | Feature: call-log-deletion, Property 4: Delete all removes all JSON files and returns correct count |
+| `tests/property/call-log-deletion.property.test.js` | Property 5 | Feature: call-log-deletion, Property 5: Delete all preserves non-JSON files |
+
+**PBT Library:** `fast-check` (already installed)
+
+**Test Runner:** `vitest --run`
+
+**Generators needed:**
+- `fc.string()` / `fc.stringMatching(...)` — for call log IDs, filenames
+- `fc.nat()` — for generating N files to populate a temp directory
+- `fc.array(fc.string())` — for generating sets of filenames
+- `fc.constantFrom('.json', '.txt', '.log', '.md')` — for file extension mixing
+
+Each property test must be tagged with a comment in the format:
+```
+// Feature: call-log-deletion, Property N: <property title>
+```
+
+Each property test must run a minimum of 100 iterations (`{ numRuns: 100 }`).

--- a/.kiro/specs/call-log-deletion/requirements.md
+++ b/.kiro/specs/call-log-deletion/requirements.md
@@ -1,0 +1,58 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds call log deletion capabilities to the admin panel of the AI Phone Receptionist. Administrators need the ability to delete individual call logs or all call logs at once from the admin dashboard. Call summaries are stored as JSON files in the `call-summaries/` directory and are currently view-only through the admin panel at `public/admin/calls.html`.
+
+## Glossary
+
+- **Admin_Panel**: The web-based administration dashboard served at `/admin/`, used by practice administrators to manage the AI Phone Receptionist system.
+- **Call_Log**: A JSON file stored in the `call-summaries/` directory containing call metadata, AI-generated summary, and full transcript for a single phone call.
+- **Call_Logs_Page**: The admin panel page at `/admin/calls.html` that displays paginated call history with details.
+- **Server**: The Express.js backend (`src/server.js`) that serves admin API endpoints under `/admin/api/`.
+- **Call_Summary_Manager**: The module (`src/call-summary.js`) responsible for reading, writing, and managing call summary JSON files.
+
+## Requirements
+
+### Requirement 1: Delete a Single Call Log
+
+**User Story:** As a practice administrator, I want to delete a specific call log from the call logs page, so that I can remove outdated or irrelevant call records individually.
+
+#### Acceptance Criteria
+
+1. THE Call_Logs_Page SHALL display a delete button for each call log entry in the call history table.
+2. WHEN the administrator clicks the delete button for a specific call log, THE Call_Logs_Page SHALL display a confirmation dialog asking the administrator to confirm the deletion.
+3. WHEN the administrator confirms the deletion, THE Call_Logs_Page SHALL send a delete request to the Server, and the Server SHALL remove the matching Call_Log file from the `call-summaries/` directory.
+4. WHEN the Server successfully deletes the Call_Log, THE Call_Logs_Page SHALL remove the corresponding row from the table and display a success toast notification.
+5. IF the specified Call_Log does not exist, THEN THE Server SHALL return an error response with HTTP status 404, and THE Call_Logs_Page SHALL display an error toast notification.
+6. IF an unexpected error occurs during deletion, THEN THE Server SHALL return an error response with HTTP status 500, and THE Call_Logs_Page SHALL display an error toast notification with the error message.
+7. THE Server SHALL sanitize the call log ID parameter using `path.basename` to prevent directory traversal attacks before performing any file system operation.
+8. THE Server SHALL require the request to pass through the existing admin authentication middleware before processing the deletion.
+
+### Requirement 2: Delete All Call Logs
+
+**User Story:** As a practice administrator, I want to delete all call logs at once from the call logs page, so that I can clear the entire call history efficiently without removing records one by one.
+
+#### Acceptance Criteria
+
+1. THE Call_Logs_Page SHALL display a "Delete All" button in the call history card header area, styled as a danger button.
+2. WHEN the administrator clicks the "Delete All" button, THE Call_Logs_Page SHALL display a confirmation dialog warning that all call logs will be permanently deleted.
+3. WHEN the administrator confirms the deletion, THE Call_Logs_Page SHALL send a delete request to the Server, and the Server SHALL remove all Call_Log JSON files from the `call-summaries/` directory.
+4. WHEN the Server successfully deletes all Call_Logs, THE Call_Logs_Page SHALL display a success toast notification showing the count of deleted call logs and reload the call list.
+5. IF the `call-summaries/` directory contains no Call_Log files, THEN THE Server SHALL return a success response with a count of zero deleted files.
+6. IF an error occurs while deleting Call_Log files, THEN THE Server SHALL return an error response with HTTP status 500, and THE Call_Logs_Page SHALL display an error toast notification with the error message.
+7. THE Server SHALL only delete files with the `.json` extension from the `call-summaries/` directory during a delete-all operation.
+8. WHILE the delete-all operation is in progress, THE Call_Logs_Page SHALL disable the "Delete All" button to prevent duplicate requests.
+9. THE Server SHALL require the request to pass through the existing admin authentication middleware before processing the deletion.
+
+### Requirement 3: Call Summary Manager Deletion Support
+
+**User Story:** As a developer, I want the Call_Summary_Manager to support deletion operations, so that the Server can reliably delete call log files through a consistent interface.
+
+#### Acceptance Criteria
+
+1. THE Call_Summary_Manager SHALL provide a `deleteSummaryById` method that accepts a call log ID and deletes the corresponding JSON file from the `call-summaries/` directory.
+2. THE Call_Summary_Manager SHALL provide a `deleteAllSummaries` method that deletes all JSON files from the `call-summaries/` directory and returns the count of deleted files.
+3. WHEN `deleteSummaryById` is called with an ID that does not match any file, THE Call_Summary_Manager SHALL return `false`.
+4. WHEN `deleteSummaryById` is called with a valid ID, THE Call_Summary_Manager SHALL delete the file and return `true`.
+5. THE Call_Summary_Manager SHALL sanitize all ID parameters using `path.basename` to prevent directory traversal before performing file operations.

--- a/.kiro/specs/call-log-deletion/tasks.md
+++ b/.kiro/specs/call-log-deletion/tasks.md
@@ -1,0 +1,92 @@
+# Implementation Plan: Call Log Deletion
+
+## Overview
+
+Add delete single and delete all capabilities to the call logs page in the admin panel. Two new methods on `CallSummaryManager`, two new DELETE endpoints on the Express server, and UI controls on `calls.html`. No new dependencies needed.
+
+## Tasks
+
+- [x] 0. Create feature branch
+  - [x] 0.1 Create and switch to a new git branch `feature/call-log-deletion` from the current branch
+
+- [x] 1. Add deletion methods to CallSummaryManager
+  - [x] 1.1 Add `deleteSummaryById(id)` method to `src/call-summary.js`
+    - Sanitize `id` with `path.basename()` to prevent directory traversal
+    - Append `.json` if not already present
+    - Return `true` if file existed and was deleted, `false` if not found
+    - Use `fs.unlinkSync` for deletion
+    - _Requirements: 3.1, 3.3, 3.4, 3.5_
+
+  - [x] 1.2 Add `deleteAllSummaries()` method to `src/call-summary.js`
+    - Read directory, filter to `.json` files only
+    - Delete each `.json` file with `fs.unlinkSync`
+    - Return count of deleted files (0 if directory was empty)
+    - _Requirements: 3.2, 2.5, 2.7_
+
+  - [ ]* 1.3 Write property test for single delete (Property 1)
+    - **Property 1: Delete single existing call log**
+    - For any existing call summary file, `deleteSummaryById` removes it and returns `true`
+    - Use temp directory with generated JSON files
+    - **Validates: Requirements 1.3, 3.1, 3.4**
+
+  - [ ]* 1.4 Write property test for non-existent delete (Property 2)
+    - **Property 2: Delete non-existent call log returns false**
+    - For any ID not matching an existing file, `deleteSummaryById` returns `false` and directory is unchanged
+    - **Validates: Requirements 1.5, 3.3**
+
+  - [ ]* 1.5 Write property test for path traversal sanitization (Property 3)
+    - **Property 3: Path traversal sanitization**
+    - For any string with path separators or `../`, the resolved path stays within `call-summaries/`
+    - **Validates: Requirements 1.7, 3.5**
+
+  - [ ]* 1.6 Write property test for delete all (Property 4)
+    - **Property 4: Delete all removes all JSON files and returns correct count**
+    - For any directory with N JSON files, `deleteAllSummaries` returns N and zero JSON files remain
+    - **Validates: Requirements 2.3, 3.2**
+
+  - [ ]* 1.7 Write property test for non-JSON preservation (Property 5)
+    - **Property 5: Delete all preserves non-JSON files**
+    - For any directory with mixed file types, only `.json` files are removed
+    - **Validates: Requirements 2.7**
+
+- [x] 2. Add DELETE API endpoints to server
+  - [x] 2.1 Add `DELETE /admin/api/calls/:id` endpoint to `src/server.js`
+    - Sanitize `req.params.id` with `path.basename()` (defense in depth)
+    - Call `callSummaryManager.deleteSummaryById(id)`
+    - Return 200 on success, 404 if not found, 500 on error
+    - Log deletion with error buffer on failure
+    - _Requirements: 1.3, 1.5, 1.6, 1.7, 1.8_
+
+  - [x] 2.2 Add `DELETE /admin/api/calls` endpoint to `src/server.js`
+    - Call `callSummaryManager.deleteAllSummaries()`
+    - Return 200 with `{ success: true, deletedCount: N }`
+    - Return 500 on error
+    - Log deletion with error buffer on failure
+    - _Requirements: 2.3, 2.5, 2.6, 2.9_
+
+- [x] 3. Add deletion UI to calls page
+  - [x] 3.1 Add "Delete All" button and per-row delete buttons to `public/admin/calls.html`
+    - Add "Delete All" button (`.btn-danger`) in the card header next to "Call History" heading
+    - Add delete button (🗑️) in each table row's Actions column
+    - Single delete: `confirm()` dialog, then `DELETE /admin/api/calls/:id`, remove row from DOM, show success toast
+    - Delete all: `confirm()` dialog, then `DELETE /admin/api/calls`, show success toast with count, reload call list
+    - Disable "Delete All" button while request is in flight
+    - _Requirements: 1.1, 1.2, 1.4, 2.1, 2.2, 2.4, 2.8_
+
+- [ ] 4. Write unit tests for API endpoints
+  - [ ]* 4.1 Write unit tests in `tests/unit/call-log-deletion.test.js`
+    - `DELETE /admin/api/calls/:id` returns 404 for non-existent ID
+    - `DELETE /admin/api/calls/:id` returns 200 for existing ID
+    - `DELETE /admin/api/calls` returns 200 with `deletedCount: 0` for empty directory
+    - `DELETE /admin/api/calls/:id` returns 401 without auth session
+    - `DELETE /admin/api/calls` returns 401 without auth session
+    - _Requirements: 1.5, 1.6, 1.8, 2.5, 2.6, 2.9_
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Property tests use `fast-check` with minimum 100 iterations per property
+- All property tests go in `tests/property/call-log-deletion.property.test.js`
+- Unit tests go in `tests/unit/call-log-deletion.test.js`
+- No new npm dependencies needed

--- a/.kiro/specs/post-call-agent-testing/.config.kiro
+++ b/.kiro/specs/post-call-agent-testing/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "89a307d2-1850-4fb6-8fbf-62ea66896f42", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/post-call-agent-testing/design.md
+++ b/.kiro/specs/post-call-agent-testing/design.md
@@ -1,0 +1,205 @@
+# Design Document: Post-Call Agent Testing
+
+## Overview
+
+A lean test harness that replays stored call fixtures through the real `runPostCallAgent` function. No mocking, no assertion framework beyond basic completion checks — the real agent tools (OpenRouter, provider profiles, email, etc.) run as-is. The only thing avoided is making actual phone calls.
+
+The harness consists of three pieces:
+1. **Call fixtures** — JSON files in `tests/simulated_call_bank/` matching the `callData` shape that `runPostCallAgent` accepts.
+2. **A vitest test file** — loads fixtures, calls the real agent, and reports which tools were invoked.
+3. **A seed utility** — converts existing call summary JSON files into the fixture format.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    F[tests/simulated_call_bank/*.json] -->|load & validate| T[post-call-agent.test.js]
+    T -->|callData| A[runPostCallAgent]
+    A -->|real calls| Tools[save_call_summary\nread_provider_profiles\nsend_email\nread_call_summaries]
+    A -->|writes| Logs[data/agent_logs/]
+    S[call-summaries/*.json] -->|seed-fixture.js| F
+```
+
+The test file is a standard vitest file. It reads every `.json` file from the call bank directory, validates the shape, and runs each through the agent. Tests are tagged with `@integration` since they hit real external services (OpenRouter).
+
+There is no custom runner or framework — just vitest `describe`/`it` blocks.
+
+## Components and Interfaces
+
+### 1. Fixture Loader & Validator (`tests/simulated_call_bank/loader.js`)
+
+A small module that:
+- Reads all `.json` files from `tests/simulated_call_bank/`
+- Validates each fixture has the required fields: `callSid`, `from`, `to`, `startTime`, `endTime`, `conversationHistory`
+- Validates `conversationHistory` is an array of `{ role, content }` objects
+- Returns an array of `{ filename, data }` objects
+- Can load a single fixture by filename
+
+```js
+// Interface
+module.exports = {
+  loadAllFixtures()          // → [{ filename, data }]
+  loadFixture(filename)      // → { filename, data } | throws
+  validateFixture(data, filename) // → throws on invalid
+};
+```
+
+### 2. Test File (`tests/integration/post-call-agent.test.js`)
+
+A vitest test file that:
+- Uses the loader to get fixtures
+- For each fixture, calls `runPostCallAgent(fixture.data)`
+- Reports success/failure and which tools were called (from agent logs)
+- Supports running a single fixture via `FIXTURE=filename.json` env var
+
+### 3. Seed Utility (`tests/simulated_call_bank/seed-fixture.js`)
+
+A Node.js script that converts a call summary into a fixture:
+- Reads a call summary JSON from `call-summaries/`
+- Maps `fullTranscript[].speaker` → `conversationHistory[].role` (Caller → user, AI Receptionist → assistant)
+- Handles both flat and nested summary structures
+- Preserves `callSid`, maps `callerPhone` → `from`, `twilioNumber` → `to`, preserves `startTime` and `endTime`
+- Writes the fixture to `tests/simulated_call_bank/`
+
+```js
+// Usage: node tests/simulated_call_bank/seed-fixture.js call-summaries/call-2026-03-15-12-50-31-CAc26ac1.json
+```
+
+## Data Models
+
+### Call Fixture Shape
+
+This is identical to the `callData` parameter accepted by `runPostCallAgent`:
+
+```json
+{
+  "callSid": "CA9a4c2121811dad654a67cf665fb60651",
+  "from": "+15551234567",
+  "to": "+18557072970",
+  "startTime": "2026-03-15T12:48:25",
+  "endTime": "2026-03-15T12:50:31",
+  "conversationHistory": [
+    { "role": "assistant", "content": "Hello! Thank you for calling..." },
+    { "role": "user", "content": "I'm looking for a therapist." }
+  ]
+}
+```
+
+### Call Summary Shape (input to seed utility)
+
+Two variants exist in the wild:
+
+**Flat structure** (older summaries):
+```json
+{
+  "callSid": "CA...",
+  "callerPhone": "+15551234567",
+  "twilioNumber": "+18557072970",
+  "startTime": "...",
+  "endTime": "...",
+  "summary": "text...",
+  "fullTranscript": [{ "speaker": "Caller", "message": "..." }]
+}
+```
+
+**Nested structure** (newer summaries):
+```json
+{
+  "callSid": "CA...",
+  "summary": {
+    "callerPhone": "+15551234567",
+    "callDate": "...",
+    "duration": "...",
+    "summary": "text...",
+    "fullTranscript": [{ "speaker": "Caller", "message": "..." }]
+  }
+}
+```
+
+The seed utility handles both by checking whether `summary` is an object with `callerPhone` inside it.
+
+### Required Fixture Fields
+
+| Field | Type | Required |
+|-------|------|----------|
+| `callSid` | string | yes |
+| `from` | string | yes |
+| `to` | string | yes |
+| `startTime` | string | yes |
+| `endTime` | string | yes |
+| `conversationHistory` | array of `{role, content}` | yes |
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Fixture validation rejects missing fields with informative errors
+
+*For any* JSON object that is missing one or more of the required fixture fields (`callSid`, `from`, `to`, `startTime`, `endTime`, `conversationHistory`), calling `validateFixture(data, filename)` should throw an error whose message contains both the filename and the name of the missing field.
+
+**Validates: Requirements 1.2, 1.4**
+
+### Property 2: Seed conversion preserves fields and produces valid fixtures
+
+*For any* valid call summary (flat or nested structure) containing `callSid`, `callerPhone`, `twilioNumber`, `startTime`, `endTime`, and `fullTranscript`, converting it with the seed utility should produce a fixture where: `fixture.callSid === summary.callSid`, `fixture.from === summary.callerPhone`, `fixture.to === summary.twilioNumber`, `fixture.startTime === summary.startTime`, `fixture.endTime === summary.endTime`, and `fixture.conversationHistory` is a valid array of `{ role, content }` objects.
+
+**Validates: Requirements 4.1, 4.3**
+
+### Property 3: Speaker-to-role mapping is correct
+
+*For any* transcript entry with speaker `"Caller"`, the converted `conversationHistory` entry should have role `"user"`. *For any* transcript entry with speaker `"AI Receptionist"`, the converted entry should have role `"assistant"`. The `content` field should equal the original `message` field.
+
+**Validates: Requirements 4.2**
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Fixture missing required field | `validateFixture` throws with filename + field name in message |
+| Fixture file not found | `loadFixture` throws with the missing filename in message |
+| Call bank directory empty | `loadAllFixtures` returns empty array; test reports "no fixtures found" |
+| Call bank directory missing | `loadAllFixtures` returns empty array (directory created on first seed) |
+| Agent throws during execution | Test catches error, reports it as failure for that fixture, continues to next |
+| Seed utility given nested summary | Flattens `summary` object to extract `callerPhone`, `fullTranscript`, etc. |
+| Seed utility given unknown speaker | Maps to `"user"` as fallback (conservative — treats unknown speakers as callers) |
+| OpenRouter API failure | Agent error propagates; test reports the fixture as failed |
+
+## Testing Strategy
+
+### Unit Tests
+
+Unit tests cover the pure logic that doesn't require external services:
+
+- **Fixture validation**: Test that valid fixtures pass, and fixtures missing each required field are rejected with the correct error message.
+- **Seed conversion**: Test that both flat and nested call summary structures are correctly converted to fixture format.
+- **Speaker mapping**: Test the Caller → user and AI Receptionist → assistant mapping.
+- **Edge cases**: Empty `conversationHistory`, missing `twilioNumber` in nested summaries, unknown speaker names.
+
+### Property-Based Tests
+
+Property-based tests use `fast-check` (already available in the project) to verify universal properties across randomly generated inputs. Each property test runs a minimum of 100 iterations.
+
+Each test is tagged with a comment referencing the design property:
+- **Feature: post-call-agent-testing, Property 1: Fixture validation rejects missing fields with informative errors**
+- **Feature: post-call-agent-testing, Property 2: Seed conversion preserves fields and produces valid fixtures**
+- **Feature: post-call-agent-testing, Property 3: Speaker-to-role mapping is correct**
+
+Property tests go in `tests/property/post-call-agent-testing.property.test.js`.
+
+### Integration Tests
+
+Integration tests live in `tests/integration/post-call-agent.test.js` and hit real external services. They should be excluded from the default vitest run (added to `vitest.config.js` exclude list) and run manually:
+
+```bash
+# Run all fixtures through the real agent
+npx vitest run tests/integration/post-call-agent.test.js
+
+# Run a single fixture
+FIXTURE=sample-call.json npx vitest run tests/integration/post-call-agent.test.js
+```
+
+These tests verify:
+- The agent completes without throwing for each fixture
+- Tool calls are logged and reported
+- Agent logs are written to `data/agent_logs/`

--- a/.kiro/specs/post-call-agent-testing/requirements.md
+++ b/.kiro/specs/post-call-agent-testing/requirements.md
@@ -1,0 +1,56 @@
+# Requirements Document
+
+## Introduction
+
+A test suite for the post-call processing agent that allows developers to replay simulated or real call data through the agent without making actual phone calls. The suite stores call fixtures in `tests/simulated_call_bank/`, provides a runner that can execute the agent against a single call or all calls, and lets the real agent tools run (OpenRouter, provider profiles, etc.) — the only thing avoided is placing actual phone calls. This eliminates the need to place real calls when debugging post-call agent bugs.
+
+## Glossary
+
+- **Test_Runner**: The vitest-based test harness that loads call fixtures and executes the post-call agent against them
+- **Call_Fixture**: A JSON file in `tests/simulated_call_bank/` containing simulated or real call data (callSid, from, to, startTime, endTime, conversationHistory)
+- **Post_Call_Agent**: The existing `runPostCallAgent` function in `src/agents/post-call-agent.js` that processes call data after a call ends
+- **Agent_Log**: The JSON debug log saved by the post-call agent to `data/agent_logs/`
+- **Call_Bank**: The `tests/simulated_call_bank/` directory containing call fixture files
+
+## Requirements
+
+### Requirement 1: Call Fixture Storage
+
+**User Story:** As a developer, I want to store simulated call data as JSON fixtures in a dedicated directory, so that I can replay them through the post-call agent without making real calls.
+
+#### Acceptance Criteria
+
+1. THE Call_Bank SHALL store call fixture files as JSON in `tests/simulated_call_bank/`
+2. WHEN a call fixture is loaded, THE Test_Runner SHALL validate that the fixture contains the required fields: callSid, from, to, startTime, endTime, and conversationHistory
+3. THE Call_Fixture SHALL use the same data shape as the `callData` parameter accepted by the Post_Call_Agent: `{ callSid, from, to, startTime, endTime, conversationHistory: [{ role, content }] }`
+4. WHEN a call fixture has an invalid or missing required field, THE Test_Runner SHALL report a clear validation error identifying the fixture file and the missing field
+
+### Requirement 2: Single Call Execution
+
+**User Story:** As a developer, I want to run the post-call agent against a specific call fixture, so that I can debug a particular call scenario in isolation.
+
+#### Acceptance Criteria
+
+1. WHEN a specific fixture filename is provided, THE Test_Runner SHALL execute the Post_Call_Agent with only that fixture's call data
+2. WHEN the Post_Call_Agent completes processing a single fixture, THE Test_Runner SHALL report which tools were called and their arguments
+3. IF the specified fixture file does not exist, THEN THE Test_Runner SHALL report an error identifying the missing file
+
+### Requirement 3: All Calls Execution
+
+**User Story:** As a developer, I want to run the post-call agent against all call fixtures in the bank, so that I can verify agent behavior across a range of scenarios.
+
+#### Acceptance Criteria
+
+1. WHEN no specific fixture is specified, THE Test_Runner SHALL execute the Post_Call_Agent against every fixture file in the Call_Bank
+2. THE Test_Runner SHALL report results for each fixture independently, including pass/fail status and tool calls made
+3. IF the Call_Bank directory is empty, THEN THE Test_Runner SHALL report that no fixtures were found
+
+### Requirement 4: Seed Fixtures from Real Call Data
+
+**User Story:** As a developer, I want to easily create new fixtures from existing call summaries, so that I can reproduce real-world bugs without manually crafting test data.
+
+#### Acceptance Criteria
+
+1. THE Test_Runner SHALL provide a utility function that converts a call summary JSON (from `call-summaries/`) into the call fixture format expected by the Post_Call_Agent
+2. WHEN converting a call summary, THE utility SHALL map `fullTranscript[].speaker` back to `conversationHistory[].role` (Caller → user, AI Receptionist → assistant)
+3. WHEN converting a call summary, THE utility SHALL preserve callSid, callerPhone (as `from`), twilioNumber (as `to`), startTime, and endTime

--- a/.kiro/specs/post-call-agent-testing/tasks.md
+++ b/.kiro/specs/post-call-agent-testing/tasks.md
@@ -1,0 +1,85 @@
+# Implementation Plan: Post-Call Agent Testing
+
+## Overview
+
+Build a lean test harness that replays stored call fixtures through the real `runPostCallAgent` function. Three components: fixture loader/validator, seed utility, and integration test file. Property tests use fast-check to verify fixture validation, seed conversion, and speaker mapping. Integration tests are excluded from the default vitest run.
+
+## Tasks
+
+- [x] 1. Create fixture loader and validator
+  - [x] 1.1 Create `tests/simulated_call_bank/loader.js` with `loadAllFixtures()`, `loadFixture(filename)`, and `validateFixture(data, filename)`
+    - Read all `.json` files from `tests/simulated_call_bank/`
+    - Validate required fields: `callSid`, `from`, `to`, `startTime`, `endTime`, `conversationHistory`
+    - Validate `conversationHistory` is an array of `{ role, content }` objects
+    - Throw errors that include both the filename and the missing field name
+    - `loadAllFixtures()` returns `[{ filename, data }]`, returns empty array if directory is empty or missing
+    - `loadFixture(filename)` returns `{ filename, data }` or throws with the missing filename in the message
+    - _Requirements: 1.1, 1.2, 1.3, 1.4_
+
+  - [ ]* 1.2 Write property test for fixture validation (Property 1)
+    - **Property 1: Fixture validation rejects missing fields with informative errors**
+    - Use fast-check to generate JSON objects missing one or more required fields
+    - Assert `validateFixture` throws with both filename and missing field name in the error message
+    - Place in `tests/property/post-call-agent-testing.property.test.js`
+    - **Validates: Requirements 1.2, 1.4**
+
+- [x] 2. Create seed utility
+  - [x] 2.1 Create `tests/simulated_call_bank/seed-fixture.js` CLI script
+    - Accept a call summary JSON path as CLI argument
+    - Handle both flat and nested summary structures (check if `summary` is an object with `callerPhone`)
+    - Map `callerPhone` → `from`, `twilioNumber` → `to`, preserve `callSid`, `startTime`, `endTime`
+    - Map `fullTranscript[].speaker` to `conversationHistory[].role`: `"Caller"` → `"user"`, `"AI Receptionist"` → `"assistant"`, unknown → `"user"`
+    - Map `fullTranscript[].message` to `conversationHistory[].content`
+    - Write output fixture to `tests/simulated_call_bank/`
+    - Usage: `node tests/simulated_call_bank/seed-fixture.js call-summaries/call-2026-03-15-12-50-31-CAc26ac1.json`
+    - _Requirements: 4.1, 4.2, 4.3_
+
+  - [ ]* 2.2 Write property test for seed conversion (Property 2)
+    - **Property 2: Seed conversion preserves fields and produces valid fixtures**
+    - Use fast-check to generate valid call summary objects (both flat and nested)
+    - Assert converted fixture preserves `callSid`, maps `callerPhone` → `from`, `twilioNumber` → `to`, preserves `startTime` and `endTime`
+    - Assert `conversationHistory` is a valid array of `{ role, content }` objects
+    - Place in `tests/property/post-call-agent-testing.property.test.js`
+    - **Validates: Requirements 4.1, 4.3**
+
+  - [ ]* 2.3 Write property test for speaker-to-role mapping (Property 3)
+    - **Property 3: Speaker-to-role mapping is correct**
+    - Use fast-check to generate transcript entries with speaker `"Caller"` or `"AI Receptionist"`
+    - Assert `"Caller"` maps to `"user"`, `"AI Receptionist"` maps to `"assistant"`, and `content` equals original `message`
+    - Place in `tests/property/post-call-agent-testing.property.test.js`
+    - **Validates: Requirements 4.2**
+
+- [x] 3. Seed a sample fixture and checkpoint
+  - [x] 3.1 Run the seed utility against `call-summaries/call-2026-03-15-12-50-31-CAc26ac1.json` to create a sample fixture in `tests/simulated_call_bank/`
+    - Verify the output fixture passes `validateFixture`
+    - _Requirements: 1.1, 1.3, 4.1_
+
+  - [x] 3.2 Checkpoint - Ensure all tests pass
+    - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 4. Create integration test file
+  - [x] 4.1 Create `tests/integration/post-call-agent.test.js`
+    - Use vitest `describe`/`it` blocks
+    - Load fixtures via the loader module
+    - Support `FIXTURE` env var to run a single fixture
+    - For each fixture, call `runPostCallAgent(fixture.data)` and assert it completes without throwing
+    - Report which tools were called (from agent result/logs)
+    - Handle agent errors per-fixture (catch, report as failure, continue to next)
+    - Set a generous test timeout (120s+) since these hit real OpenRouter
+    - Report "no fixtures found" if call bank is empty
+    - _Requirements: 2.1, 2.2, 2.3, 3.1, 3.2, 3.3_
+
+  - [x] 4.2 Exclude integration tests from default vitest run
+    - Add `tests/integration/post-call-agent.test.js` to the `exclude` array in `vitest.config.js`
+    - _Requirements: 3.1_
+
+- [x] 5. Final checkpoint
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Integration tests hit real OpenRouter and should be run manually: `npx vitest run tests/integration/post-call-agent.test.js`
+- Single fixture run: `FIXTURE=sample-call.json npx vitest run tests/integration/post-call-agent.test.js`
+- Property tests use fast-check (already in the project)
+- All code is CommonJS (require/module.exports)

--- a/.kiro/specs/post-call-agents/.config.kiro
+++ b/.kiro/specs/post-call-agents/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "8dc15785-b36c-4876-b304-f6cf00dc6d56", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/post-call-agents/design.md
+++ b/.kiro/specs/post-call-agents/design.md
@@ -1,0 +1,589 @@
+# Design Document: Provider Call Notification
+
+## Overview
+
+This feature replaces the standalone `generateSummary()` AI call in `call-summary.js` with an AI agent-driven post-call processing pipeline, and adds a daily digest email agent. Both agents use the Vercel AI SDK (`ai` package) for tool-calling orchestration, with all decision-making logic living in editable prompt files rather than application code.
+
+The system introduces two agents:
+1. **Post-Call Agent** — triggered after each call ends, absorbs summary generation, saves the summary via tool, optionally emails relevant providers.
+2. **Daily Digest Agent** — triggered on a cron schedule, reads the day's summaries and composes a digest email to the admin.
+
+Both agents share a common set of thin tool adapters (10-20 lines each) that wrap existing modules: `CallSummaryManager`, `ProviderLoader`, and a new `nodemailer` transport.
+
+### Key Design Decisions
+
+- **Vercel AI SDK over LangChain**: The `ai` package is lighter, has first-class OpenAI-compatible API support (which OpenRouter is), built-in tool calling with automatic loop handling, and less abstraction overhead. The project already uses the `openai` npm package for OpenRouter access.
+- **CommonJS throughout**: The project uses `require`/`module.exports`. The Vercel AI SDK supports CommonJS.
+- **Prompts on disk**: Agent behavior is defined in `prompts/post-call-agent.txt` and `prompts/daily-digest-agent.txt`, read from disk on each invocation. No restart needed to change behavior.
+- **Post-call agent absorbs summary generation**: The current `generateSummary()` in `call-summary.js` is removed. The post-call agent receives the transcript, generates the summary, and saves it via the `save_call_summary` tool.
+- **Tools are thin adapters**: Each tool is 10-20 lines wrapping an existing module method.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Triggers
+        CH[call-handler.js<br/>endCall]
+        RS[relay-service.js<br/>cleanup]
+        CRON[server.js<br/>node-cron scheduler]
+    end
+
+    subgraph Agents
+        PCA[Post-Call Agent<br/>src/agents/post-call-agent.js]
+        DDA[Daily Digest Agent<br/>src/agents/daily-digest-agent.js]
+    end
+
+    subgraph Tools [Shared Tools — src/agents/tools.js]
+        T1[save_call_summary]
+        T2[read_provider_profiles]
+        T3[read_call_summaries]
+        T4[send_email]
+    end
+
+    subgraph Existing Modules
+        CSM[CallSummaryManager<br/>call-summary.js]
+        PL[ProviderLoader<br/>provider-loader.js]
+        ET[Email Transport<br/>src/email-transport.js]
+    end
+
+    subgraph Prompts
+        P1[prompts/post-call-agent.txt]
+        P2[prompts/daily-digest-agent.txt]
+    end
+
+    CH -->|transcript + metadata| PCA
+    RS -->|transcript + metadata| PCA
+    CRON -->|daily schedule| DDA
+
+    PCA --> T1 & T2 & T4
+    DDA --> T2 & T3 & T4
+
+    T1 --> CSM
+    T2 --> PL
+    T3 --> CSM
+    T4 --> ET
+
+    PCA -.->|reads| P1
+    DDA -.->|reads| P2
+```
+
+### Flow: Post-Call Agent
+
+1. Call ends → `call-handler.js` or `relay-service.js` calls `runPostCallAgent(callData)` asynchronously (fire-and-forget with error logging).
+2. `post-call-agent.js` reads `prompts/post-call-agent.txt` from disk.
+3. Creates a Vercel AI SDK `generateText()` call with the prompt, transcript, and call metadata as the user message, plus the three tools: `save_call_summary`, `read_provider_profiles`, `send_email`.
+4. The SDK handles the tool-calling loop automatically — the agent decides what to do based on prompt instructions.
+5. If SMTP is not configured, the `send_email` tool returns an error message to the agent, which skips email.
+
+### Flow: Daily Digest Agent
+
+1. `node-cron` fires at the configured hour (default 18:00 Pacific).
+2. `daily-digest-agent.js` reads `prompts/daily-digest-agent.txt` from disk.
+3. Creates a `generateText()` call with the admin email address as context, plus tools: `read_call_summaries`, `read_provider_profiles`, `send_email`.
+4. The agent reads today's summaries, composes a digest, and sends it.
+
+## Components and Interfaces
+
+### New Files
+
+#### `src/agents/tools.js` — Shared Tool Definitions
+
+Exports an object (or function) that returns Vercel AI SDK tool definitions. Each tool is a thin adapter wrapping an existing module.
+
+```js
+// src/agents/tools.js
+const { tool } = require('ai');
+const { z } = require('zod');
+const callSummaryManager = require('../call-summary');
+const providerLoader = require('../provider-loader');
+const emailTransport = require('../email-transport');
+
+function createTools(options = {}) {
+  const tools = {
+    save_call_summary: tool({
+      description: 'Save a call summary to disk as a JSON file',
+      parameters: z.object({
+        callSid: z.string(),
+        callerPhone: z.string(),
+        twilioNumber: z.string(),
+        startTime: z.string(),
+        endTime: z.string(),
+        duration: z.string(),
+        summary: z.string(),
+        fullTranscript: z.array(z.object({
+          speaker: z.string(),
+          message: z.string()
+        }))
+      }),
+      execute: async (params) => {
+        const filepath = callSummaryManager.saveSummaryDirect(params);
+        return { success: true, filepath };
+      }
+    }),
+
+    read_provider_profiles: tool({
+      description: 'Read all provider profiles including name, email, phone, specialties',
+      parameters: z.object({}),
+      execute: async () => {
+        return providerLoader.getAll();
+      }
+    }),
+
+    read_call_summaries: tool({
+      description: 'Read call summaries, optionally filtered by date',
+      parameters: z.object({
+        date: z.string().optional().describe('ISO date string (YYYY-MM-DD) to filter summaries')
+      }),
+      execute: async ({ date }) => {
+        const summaries = callSummaryManager.getAllSummaries();
+        if (date) {
+          return summaries.filter(s => s.startTime && s.startTime.startsWith(date));
+        }
+        return summaries;
+      }
+    }),
+
+    send_email: tool({
+      description: 'Send an email to a recipient',
+      parameters: z.object({
+        to: z.string().describe('Recipient email address'),
+        subject: z.string().describe('Email subject line'),
+        body: z.string().describe('Email body text')
+      }),
+      execute: async ({ to, subject, body }) => {
+        if (!to || to.trim() === '') {
+          return { success: false, error: 'Recipient email address is missing or empty' };
+        }
+        if (!emailTransport.isConfigured()) {
+          return { success: false, error: 'Email is not configured (SMTP settings missing)' };
+        }
+        try {
+          await emailTransport.sendMail({ to, subject, body });
+          return { success: true };
+        } catch (err) {
+          return { success: false, error: `Failed to send email: ${err.message}` };
+        }
+      }
+    })
+  };
+
+  // If SMTP not configured, exclude send_email or let it return error
+  // We keep it available so the agent gets a clear error message
+  return tools;
+}
+
+module.exports = { createTools };
+```
+
+#### `src/agents/post-call-agent.js` — Post-Call Agent
+
+```js
+// src/agents/post-call-agent.js
+const fs = require('fs');
+const path = require('path');
+const { generateText } = require('ai');
+const { createOpenAI } = require('@ai-sdk/openai');
+const config = require('../config');
+const { createTools } = require('./tools');
+
+const PROMPT_PATH = path.join(__dirname, '..', '..', 'prompts', 'post-call-agent.txt');
+
+async function runPostCallAgent(callData) {
+  // Read prompt from disk on each invocation
+  let promptInstructions;
+  try {
+    promptInstructions = fs.readFileSync(PROMPT_PATH, 'utf-8').trim();
+  } catch (err) {
+    console.error('❌ Failed to read post-call agent prompt:', err.message);
+    throw err;
+  }
+
+  const openai = createOpenAI({
+    baseURL: 'https://openrouter.ai/api/v1',
+    apiKey: config.openRouter.apiKey,
+  });
+
+  const tools = createTools();
+
+  // Build user message with call data
+  const userMessage = `Call has ended. Here is the call data:
+
+Call SID: ${callData.callSid}
+Caller Phone: ${callData.from}
+Twilio Number: ${callData.to}
+Start Time: ${callData.startTime}
+End Time: ${callData.endTime}
+
+Conversation Transcript:
+${callData.conversationHistory.map(m =>
+  `${m.role === 'user' ? 'Caller' : 'AI Receptionist'}: ${m.content}`
+).join('\n')}`;
+
+  const result = await generateText({
+    model: openai(config.openRouter.model),
+    system: promptInstructions,
+    prompt: userMessage,
+    tools,
+    maxSteps: 10,
+  });
+
+  return result;
+}
+
+module.exports = { runPostCallAgent };
+```
+
+#### `src/agents/daily-digest-agent.js` — Daily Digest Agent
+
+```js
+// src/agents/daily-digest-agent.js
+const fs = require('fs');
+const path = require('path');
+const { generateText } = require('ai');
+const { createOpenAI } = require('@ai-sdk/openai');
+const config = require('../config');
+const { createTools } = require('./tools');
+
+const PROMPT_PATH = path.join(__dirname, '..', '..', 'prompts', 'daily-digest-agent.txt');
+
+async function runDailyDigestAgent(adminEmail) {
+  let promptInstructions;
+  try {
+    promptInstructions = fs.readFileSync(PROMPT_PATH, 'utf-8').trim();
+  } catch (err) {
+    console.error('❌ Failed to read daily digest agent prompt:', err.message);
+    throw err;
+  }
+
+  const openai = createOpenAI({
+    baseURL: 'https://openrouter.ai/api/v1',
+    apiKey: config.openRouter.apiKey,
+  });
+
+  const tools = createTools();
+
+  const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+
+  const userMessage = `It is now time to generate the daily digest.
+Today's date: ${today}
+Admin email: ${adminEmail}
+
+Please read today's call summaries, review them, and compose a digest email to send to the admin.`;
+
+  const result = await generateText({
+    model: openai(config.openRouter.model),
+    system: promptInstructions,
+    prompt: userMessage,
+    tools,
+    maxSteps: 10,
+  });
+
+  return result;
+}
+
+module.exports = { runDailyDigestAgent };
+```
+
+#### `src/email-transport.js` — Nodemailer SMTP Setup
+
+```js
+// src/email-transport.js
+const nodemailer = require('nodemailer');
+
+let transporter = null;
+let configured = false;
+let fromAddress = null;
+
+function initialize() {
+  const host = process.env.SMTP_HOST;
+  const port = process.env.SMTP_PORT;
+  const user = process.env.SMTP_USER;
+  const pass = process.env.SMTP_PASS;
+  const from = process.env.SMTP_FROM;
+
+  if (!host || !port || !user || !pass || !from) {
+    console.warn('⚠️ SMTP not fully configured — email notifications disabled');
+    configured = false;
+    return;
+  }
+
+  try {
+    transporter = nodemailer.createTransport({
+      host,
+      port: parseInt(port, 10),
+      secure: true, // TLS
+      auth: { user, pass }
+    });
+    fromAddress = from;
+    configured = true;
+    console.log('📧 SMTP email transport configured');
+  } catch (err) {
+    console.error('❌ SMTP configuration failed:', err.message);
+    configured = false;
+  }
+}
+
+function isConfigured() {
+  return configured;
+}
+
+async function sendMail({ to, subject, body }) {
+  if (!configured || !transporter) {
+    throw new Error('Email transport is not configured');
+  }
+  return transporter.sendMail({
+    from: fromAddress,
+    to,
+    subject,
+    text: body
+  });
+}
+
+module.exports = { initialize, isConfigured, sendMail };
+```
+
+#### `prompts/post-call-agent.txt` — Post-Call Agent Instructions
+
+A text file containing instructions for the post-call agent. Defines how to generate summaries, when to notify providers, and how to compose notification emails. Read from disk on each invocation.
+
+#### `prompts/daily-digest-agent.txt` — Daily Digest Agent Instructions
+
+A text file containing instructions for the daily digest agent. Defines how to compose the digest, what to include, and when to skip sending. Read from disk on each invocation.
+
+### Modified Files
+
+#### `src/call-summary.js`
+
+- **Remove**: `generateSummary()` method (AI call is now handled by the post-call agent).
+- **Add**: `saveSummaryDirect(summaryData)` method that accepts a pre-built summary object and writes it to disk. This is the thin adapter target for the `save_call_summary` tool.
+- **Keep**: All file I/O methods (`getAllSummaries`, `getSummariesPaginated`, `getSummaryById`, `deleteSummaryById`, `deleteAllSummaries`).
+- **Keep**: `saveCallSummary()` as a fallback for when the agent system is unavailable.
+
+#### `src/call-handler.js`
+
+- **Change**: `endCall()` method to call `runPostCallAgent()` instead of `callSummary.saveCallSummary()` directly.
+- The agent call is fire-and-forget (async, errors logged but don't block teardown).
+- If the agent fails, fall back to saving a basic summary without AI generation.
+
+#### `src/realtime/relay-service.js`
+
+- **Change**: `cleanup()` method to call `runPostCallAgent()` instead of `callSummary.saveCallSummary()` directly.
+- Same fire-and-forget pattern with fallback.
+
+#### `src/config.js`
+
+- **Add**: SMTP configuration block (`smtp.host`, `smtp.port`, `smtp.user`, `smtp.pass`, `smtp.from`).
+- **Add**: `adminEmail` from `ADMIN_EMAIL` env var.
+- **Add**: `digestScheduleHour` from `DIGEST_SCHEDULE_HOUR` env var (default: 18).
+
+#### `src/server.js`
+
+- **Add**: Import and initialize `email-transport.js` at startup.
+- **Add**: Daily digest scheduling using `node-cron` (or `setInterval` with hour check).
+- **Add**: Startup logging for notification system status (SMTP configured, digest schedule, prompt file existence).
+- **Add**: Verify prompt files exist at startup, log warnings for missing files.
+
+## Data Models
+
+### Call Data (passed to Post-Call Agent)
+
+```js
+{
+  callSid: 'CA9a4c2121...',       // Twilio Call SID
+  from: '+14255551234',            // Caller phone number
+  to: '+14255279017',              // Twilio number
+  startTime: '2026-02-14T22:18:42.308Z',
+  endTime: '2026-02-14T22:20:15.366Z',
+  conversationHistory: [
+    { role: 'user', content: 'Hello...' },
+    { role: 'assistant', content: 'Thank you for calling...' }
+  ]
+}
+```
+
+### Call Summary (saved by `save_call_summary` tool)
+
+Same shape as existing summaries in `call-summaries/`:
+
+```js
+{
+  callSid: 'CA9a4c2121...',
+  callerPhone: '+14255551234',
+  twilioNumber: '+14255279017',
+  startTime: '2026-02-14T22:18:42.308Z',
+  endTime: '2026-02-14T22:20:15.366Z',
+  duration: '93 seconds',
+  summary: 'The caller was looking for...',
+  fullTranscript: [
+    { speaker: 'Caller', message: 'Hello...' },
+    { speaker: 'AI Receptionist', message: 'Thank you...' }
+  ]
+}
+```
+
+### Email Parameters (passed to `send_email` tool)
+
+```js
+{
+  to: 'provider@example.com',
+  subject: 'New call regarding your services',
+  body: 'A caller at +14255551234 called at 2:18 PM...'
+}
+```
+
+### Config Additions
+
+```js
+// Added to config.js
+smtp: {
+  host: process.env.SMTP_HOST || null,
+  port: process.env.SMTP_PORT || null,
+  user: process.env.SMTP_USER || null,
+  pass: process.env.SMTP_PASS || null,
+  from: process.env.SMTP_FROM || null,
+},
+adminEmail: process.env.ADMIN_EMAIL || null,
+digestScheduleHour: parseInt(process.env.DIGEST_SCHEDULE_HOUR || '18', 10),
+```
+
+### New Dependencies
+
+```json
+{
+  "ai": "^4.x",
+  "@ai-sdk/openai": "^1.x",
+  "nodemailer": "^6.x",
+  "node-cron": "^3.x",
+  "zod": "^3.x"
+}
+```
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Call summary save round trip
+
+*For any* valid call summary object (with callSid, callerPhone, twilioNumber, startTime, endTime, duration, summary text, and fullTranscript array), saving it via the `save_call_summary` tool and then reading it back from disk should produce an object with identical field values.
+
+**Validates: Requirements 1.1**
+
+### Property 2: Provider profiles adapter transparency
+
+*For any* set of provider markdown files loaded into the ProviderLoader, the `read_provider_profiles` tool should return data identical to what `providerLoader.getAll()` returns directly.
+
+**Validates: Requirements 1.2**
+
+### Property 3: Call summaries date filtering and sort order
+
+*For any* collection of call summaries with various startTime dates, and any date filter string, the `read_call_summaries` tool should return only summaries whose startTime starts with that date string, and the returned array should be sorted by startTime in descending order.
+
+**Validates: Requirements 1.3**
+
+### Property 4: Send email tool validates inputs and handles transport errors
+
+*For any* string that is empty or composed entirely of whitespace, invoking the `send_email` tool with that string as the recipient should return an error result without attempting delivery. Additionally, *for any* transport error with an error message, the tool should return an error result containing that message.
+
+**Validates: Requirements 1.5, 1.6**
+
+### Property 5: Post-call agent receives complete call data
+
+*For any* call data object containing callSid, from, to, startTime, endTime, and conversationHistory, the user message constructed for the post-call agent should contain all of these values as substrings.
+
+**Validates: Requirements 2.1**
+
+### Property 6: Prompt files are read fresh from disk on each invocation
+
+*For any* prompt file path and any two distinct prompt contents, writing the first content to disk and invoking the agent setup should use the first content, then writing the second content and invoking again should use the second content — without any restart or cache invalidation.
+
+**Validates: Requirements 2.4, 3.5, 4.3, 5.5**
+
+### Property 7: Agent errors preserve call transcript
+
+*For any* call data with a conversation transcript, if the post-call agent throws an error during execution, the original call data (including the full conversationHistory) should remain unmodified and available for fallback processing.
+
+**Validates: Requirements 2.6**
+
+### Property 8: SMTP configuration completeness determines email availability
+
+*For any* subset of the five required SMTP environment variables (SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_FROM), the email transport should report `isConfigured() === true` if and only if all five variables are present and non-empty.
+
+**Validates: Requirements 6.1, 6.2**
+
+### Property 9: Digest schedule hour is configurable
+
+*For any* integer value between 0 and 23 set as `DIGEST_SCHEDULE_HOUR`, the daily digest scheduler should use that value as the trigger hour. When the variable is absent, it should default to 18.
+
+**Validates: Requirements 4.7**
+
+## Error Handling
+
+### Post-Call Agent Errors
+
+- The post-call agent is invoked asynchronously (fire-and-forget) from `call-handler.js` and `relay-service.js`.
+- If the agent throws, the error is caught and logged with `console.error`.
+- The original call data (transcript, metadata) is preserved in the catch block. A fallback path saves a basic summary (without AI-generated text) using the existing `saveCallSummary()` method so no call data is lost.
+- The call teardown process is never blocked by agent errors.
+
+### Daily Digest Agent Errors
+
+- The digest agent runs inside a try/catch in the cron callback.
+- Errors are logged but do not affect the main application or other scheduled tasks.
+- The cron job continues to fire on subsequent days regardless of previous failures.
+
+### Email Transport Errors
+
+- If SMTP env vars are incomplete, `emailTransport.initialize()` sets `configured = false` and logs a warning. The `send_email` tool returns an error message to the agent.
+- If `sendMail()` throws at runtime (e.g., SMTP server unreachable), the tool catches the error and returns it as a structured error result to the agent. The agent can then decide how to proceed based on its prompt instructions.
+- SMTP initialization failures do not prevent the application from starting.
+
+### Missing Prompt Files
+
+- If a prompt file doesn't exist when an agent is invoked, the agent function throws, which is caught by the fire-and-forget wrapper. The error is logged.
+- At startup, the system checks for prompt file existence and logs warnings for missing files, giving the operator a heads-up before any calls come in.
+
+### Tool Execution Errors
+
+- Each tool's `execute` function wraps its logic in try/catch and returns structured `{ success: false, error: '...' }` results rather than throwing. This lets the AI agent see the error and decide what to do next (retry, skip, etc.).
+
+## Testing Strategy
+
+### Property-Based Testing
+
+Use `fast-check` (already in devDependencies) for property-based tests. Each property test runs a minimum of 100 iterations.
+
+Each property test must be tagged with a comment referencing the design property:
+```
+// Feature: provider-call-notification, Property N: <property text>
+```
+
+Property tests focus on:
+- **Property 1**: Generate random call summary objects, save via tool, read back, assert equality.
+- **Property 2**: Generate random provider file sets, load them, call tool, assert output matches `getAll()`.
+- **Property 3**: Generate random summary arrays with various dates, apply date filter, assert filtering correctness and descending sort order.
+- **Property 4**: Generate random whitespace strings for empty-email validation; generate random Error objects for transport error forwarding.
+- **Property 5**: Generate random call data objects, build the user message string, assert all field values appear as substrings.
+- **Property 6**: Generate random prompt content pairs, write/read/assert fresh reads.
+- **Property 7**: Generate random call data, simulate agent failure, assert call data is unmodified.
+- **Property 8**: Generate random subsets of 5 SMTP env vars, initialize transport, assert `isConfigured()` matches completeness.
+- **Property 9**: Generate random hours 0-23, set env var, assert scheduler uses that hour.
+
+### Unit Testing
+
+Unit tests complement property tests for specific examples and edge cases:
+- Verify `send_email` tool with a valid email, subject, and body calls `sendMail` with correct params.
+- Verify `save_call_summary` tool creates a file with the expected filename pattern.
+- Verify `read_call_summaries` with no date filter returns all summaries.
+- Verify daily digest is not scheduled when `ADMIN_EMAIL` is missing.
+- Verify SMTP transport uses `secure: true` (TLS).
+- Verify startup logs include notification system status messages.
+- Verify post-call agent fallback saves a basic summary when agent throws.
+
+### Test Configuration
+
+- **Library**: `fast-check` ^4.5.3 (already installed)
+- **Runner**: `vitest` (already configured)
+- **Minimum iterations**: 100 per property test
+- **Test location**: `tests/property/` for property tests, `tests/unit/` for unit tests
+- **Mocking**: Mock `nodemailer` transport, mock `fs` for prompt file tests, mock AI SDK `generateText` to avoid real API calls in tests.

--- a/.kiro/specs/post-call-agents/requirements.md
+++ b/.kiro/specs/post-call-agents/requirements.md
@@ -1,0 +1,107 @@
+# Requirements Document
+
+## Introduction
+
+AI-agent-driven post-call processing and notification system for the AI phone receptionist. The system replaces the current standalone call summary generation (`call-summary.js` `generateSummary()`) with an AI agent that handles everything after a call ends: generating the summary, saving it, deciding whether providers should be notified, and sending emails. A second agent runs on a daily schedule to compose and send a digest email to the practice admin. All decision-making lives in editable prompt instruction files (`prompts/`), not in application code. The code provides only: trigger points, thin tool adapter functions that wrap existing modules, and SMTP configuration. An AI SDK library (recommended: Vercel AI SDK `ai` package) handles the agent loop, tool-calling protocol, and multi-turn conversation mechanics.
+
+## Glossary
+
+- **Post_Call_Agent**: An AI agent triggered when a call ends. Replaces the current `generateSummary()` AI call. Receives the conversation transcript and call metadata, then uses tools and prompt instructions to generate a summary, save it, optionally notify providers via email. Behavior defined in `prompts/post-call-agent.txt`.
+- **Daily_Digest_Agent**: An AI agent triggered on a daily schedule. Uses tools to read the day's call summaries and provider profiles, then composes and sends a digest email to the admin. Behavior defined in `prompts/daily-digest-agent.txt`.
+- **Prompt_Instructions**: Editable text files in the `prompts/` directory that define all agent decision-making: when to email, who to email, what to include, whether to skip. No code changes needed to adjust behavior.
+- **Agent_Tool**: A thin adapter function (10-20 lines) that wraps an existing module and exposes it as a callable tool for the AI agent. These are the code we write.
+- **Call_Summary**: A JSON object containing caller phone, AI-generated summary text, full transcript, call duration, and metadata. Stored in `call-summaries/`.
+- **Provider_Profile**: A markdown file in `data/providers/` containing a provider's credentials, email, phone, specialties, and scheduling details.
+- **CallSummaryManager**: The existing singleton module (`src/call-summary.js`) that manages call summary file I/O.
+- **Provider_Loader**: The existing singleton module (`src/provider-loader.js`) that loads provider profile markdown files.
+- **Email_Transport**: A configured nodemailer SMTP transport used to send outgoing emails.
+- **Admin_Email**: The email address configured via `ADMIN_EMAIL` environment variable to receive daily digest emails.
+
+## Requirements
+
+### Requirement 1: Agent Tool Adapters
+
+**User Story:** As a developer, I want thin adapter functions that expose existing modules as callable tools for AI agents, so that agents can read data and perform actions without duplicating existing logic.
+
+#### Acceptance Criteria
+
+1. THE system SHALL provide a `save_call_summary` Agent_Tool that accepts call summary data and delegates to `CallSummaryManager.saveCallSummary()` to persist the summary as a JSON file.
+2. THE system SHALL provide a `read_provider_profiles` Agent_Tool that delegates to `Provider_Loader.getAll()` and returns all Provider_Profile data including each provider's name, email, phone, specialties, and scheduling information.
+3. THE system SHALL provide a `read_call_summaries` Agent_Tool that accepts an optional date filter parameter and delegates to `CallSummaryManager.getAllSummaries()`, returning matching Call_Summary objects sorted by start time in descending order.
+4. THE system SHALL provide a `send_email` Agent_Tool that accepts recipient email address, subject line, and body text, and delegates to `Email_Transport.sendMail()` to deliver the email.
+5. IF the `send_email` Agent_Tool is invoked with a missing or empty recipient email address, THEN THE `send_email` Agent_Tool SHALL return an error message to the agent indicating the email could not be sent.
+6. IF the Email_Transport fails to deliver an email, THEN THE `send_email` Agent_Tool SHALL return an error message to the agent describing the failure.
+
+### Requirement 2: Post-Call Agent Trigger and Summary Migration
+
+**User Story:** As a practice administrator, I want an AI agent to automatically run after each call ends, replacing the current standalone summary generation, so that one agent flow handles summary creation, saving, and optional provider notification.
+
+#### Acceptance Criteria
+
+1. WHEN a call ends and the conversation transcript is available, THE system SHALL trigger the Post_Call_Agent with the full conversation transcript and call metadata (caller phone, call SID, start time, end time) as context.
+2. THE Post_Call_Agent SHALL replace the current standalone `generateSummary()` AI call in `CallSummaryManager.saveCallSummary()`, absorbing summary generation into the agent flow.
+3. THE Post_Call_Agent SHALL have access to the `save_call_summary`, `read_provider_profiles`, and `send_email` Agent_Tools.
+4. THE Post_Call_Agent SHALL load its Prompt_Instructions from `prompts/post-call-agent.txt` on each invocation.
+5. THE Post_Call_Agent trigger SHALL operate asynchronously and not block or delay the call teardown process.
+6. IF the Post_Call_Agent encounters an error during execution, THEN THE system SHALL log the error and preserve the conversation transcript so no call data is lost.
+7. WHEN the notification system is disabled (missing SMTP configuration), THE Post_Call_Agent SHALL still generate and save the call summary but skip any email-sending tool calls.
+
+### Requirement 3: Post-Call Agent Prompt Instructions
+
+**User Story:** As a practice administrator, I want to control how the post-call agent generates summaries, decides which providers to notify, and composes emails, by editing a prompt file rather than changing code.
+
+#### Acceptance Criteria
+
+1. THE Prompt_Instructions file `prompts/post-call-agent.txt` SHALL contain instructions that direct the Post_Call_Agent to: analyze the conversation transcript, generate a concise call summary, save the summary using the `save_call_summary` tool, decide whether any providers should be notified, and send notification emails using the `send_email` tool.
+2. THE Prompt_Instructions SHALL instruct the Post_Call_Agent to use the `read_provider_profiles` tool to look up provider contact information before sending any emails.
+3. THE Prompt_Instructions SHALL include default guidance for matching caller inquiries to providers based on names, specialties, and context mentioned in the conversation.
+4. THE Prompt_Instructions SHALL include default guidance for composing notification emails that include the caller phone number, call timestamp, and a summary of what the caller was looking for.
+5. THE Prompt_Instructions file SHALL be read from disk on each agent invocation, allowing edits to take effect without code changes or application restarts.
+
+### Requirement 4: Daily Digest Agent Trigger
+
+**User Story:** As a practice administrator, I want a daily AI agent to review all calls and send me a digest email, so that I have a complete picture of call activity without checking the dashboard.
+
+#### Acceptance Criteria
+
+1. THE system SHALL trigger the Daily_Digest_Agent once per day at a configurable time (default: 6:00 PM Pacific Time) using a scheduled timer.
+2. THE Daily_Digest_Agent SHALL have access to the `read_call_summaries`, `read_provider_profiles`, and `send_email` Agent_Tools.
+3. THE Daily_Digest_Agent SHALL load its Prompt_Instructions from `prompts/daily-digest-agent.txt` on each invocation.
+4. THE system SHALL configure the digest recipient address from the `ADMIN_EMAIL` environment variable and provide the address to the Daily_Digest_Agent as context.
+5. IF the `ADMIN_EMAIL` environment variable is not configured, THEN THE system SHALL log a warning at startup and skip scheduling the Daily_Digest_Agent.
+6. IF the Daily_Digest_Agent encounters an error during execution, THEN THE system SHALL log the error and not affect other application functionality.
+7. THE Daily_Digest_Agent scheduling SHALL be configurable via a `DIGEST_SCHEDULE_HOUR` environment variable (0-23, default: 18 for 6 PM Pacific).
+
+### Requirement 5: Daily Digest Agent Prompt Instructions
+
+**User Story:** As a practice administrator, I want to control how the daily digest is composed and what it includes, by editing a prompt file rather than changing code.
+
+#### Acceptance Criteria
+
+1. THE Prompt_Instructions file `prompts/daily-digest-agent.txt` SHALL contain instructions that direct the Daily_Digest_Agent to use the `read_call_summaries` tool to retrieve the current day's call data, review the summaries, and compose a digest email.
+2. THE Prompt_Instructions SHALL instruct the Daily_Digest_Agent to use the `read_provider_profiles` tool to enrich the digest with provider context when calls reference specific providers.
+3. THE Prompt_Instructions SHALL include default guidance for composing a digest that includes: total call count, per-call details (caller phone, timestamp, duration, summary, mentioned providers), and any notable patterns.
+4. THE Prompt_Instructions SHALL instruct the Daily_Digest_Agent to skip sending the digest when no calls occurred during the day.
+5. THE Prompt_Instructions file SHALL be read from disk on each agent invocation, allowing edits to take effect without code changes or application restarts.
+
+### Requirement 6: Email Transport Configuration
+
+**User Story:** As a system administrator, I want to configure email sending via environment variables, so that I can set up SMTP credentials without modifying code.
+
+#### Acceptance Criteria
+
+1. THE Email_Transport SHALL be configured using the following environment variables: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, and `SMTP_FROM`.
+2. WHEN any required SMTP environment variable is missing, THE system SHALL log a warning at startup and disable the `send_email` Agent_Tool (returning an error message to any agent that attempts to use the tool).
+3. THE Email_Transport SHALL use TLS encryption when connecting to the SMTP server.
+4. IF the SMTP connection fails at startup validation, THEN THE system SHALL log the error and allow the rest of the application to continue running.
+
+### Requirement 7: Notification System Startup and Status
+
+**User Story:** As a developer, I want the notification system to report its status at startup, so that I can verify the agent infrastructure is properly configured.
+
+#### Acceptance Criteria
+
+1. WHEN the application starts, THE system SHALL verify SMTP configuration and log whether the email notification capability is enabled or disabled.
+2. WHEN email capability is enabled, THE system SHALL log the scheduled time for the Daily_Digest_Agent.
+3. WHEN the application starts, THE system SHALL verify that the Prompt_Instructions files (`prompts/post-call-agent.txt` and `prompts/daily-digest-agent.txt`) exist and log warnings for any missing files.
+4. THE notification system startup SHALL not block or delay the main application startup.

--- a/.kiro/specs/post-call-agents/tasks.md
+++ b/.kiro/specs/post-call-agents/tasks.md
@@ -1,0 +1,207 @@
+# Implementation Plan: Post-Call Agents
+
+## Overview
+
+Replace the standalone `generateSummary()` AI call with an AI agent-driven post-call processing pipeline using the Vercel AI SDK. Implement two agents (post-call and daily digest), shared tool adapters, email transport, prompt instruction files, and integrate into existing call flow. All agent decision-making lives in editable prompt files.
+
+## Tasks
+
+- [x] 1. Install dependencies and update configuration
+  - [x] 1.1 Add new npm dependencies
+    - Install `ai`, `@ai-sdk/openai`, `nodemailer`, `node-cron`, `zod` as production dependencies
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 4.1_
+
+  - [x] 1.2 Add SMTP and notification config to `src/config.js`
+    - Add `smtp` block with `host`, `port`, `user`, `pass`, `from` from env vars
+    - Add `adminEmail` from `ADMIN_EMAIL` env var
+    - Add `digestScheduleHour` from `DIGEST_SCHEDULE_HOUR` env var (default: 18)
+    - _Requirements: 6.1, 4.4, 4.5, 4.7_
+
+  - [x] 1.3 Update `.env.example` with new environment variables
+    - Add `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`, `ADMIN_EMAIL`, `DIGEST_SCHEDULE_HOUR`
+    - _Requirements: 6.1, 4.4, 4.7_
+
+- [x] 2. Implement email transport module
+  - [x] 2.1 Create `src/email-transport.js`
+    - Implement `initialize()` that reads SMTP env vars and creates nodemailer transport with `secure: true`
+    - Implement `isConfigured()` returning boolean based on all 5 SMTP vars being present
+    - Implement `sendMail({ to, subject, body })` that delegates to nodemailer
+    - Log warning when SMTP not fully configured, log success when configured
+    - SMTP init failure must not prevent app from starting
+    - _Requirements: 6.1, 6.2, 6.3, 6.4_
+
+  - [ ]* 2.2 Write property test for SMTP configuration completeness
+    - **Property 8: SMTP configuration completeness determines email availability**
+    - **Validates: Requirements 6.1, 6.2**
+
+  - [ ]* 2.3 Write unit tests for email transport
+    - Test `isConfigured()` returns false when any SMTP var is missing
+    - Test `sendMail()` throws when transport not configured
+    - Test transport uses `secure: true` (TLS)
+    - _Requirements: 6.1, 6.2, 6.3_
+
+- [x] 3. Implement agent tool adapters
+  - [x] 3.1 Create `src/agents/tools.js` with shared tool definitions
+    - Implement `save_call_summary` tool wrapping `CallSummaryManager.saveSummaryDirect()`
+    - Implement `read_provider_profiles` tool wrapping `providerLoader.getAll()`
+    - Implement `read_call_summaries` tool wrapping `CallSummaryManager.getAllSummaries()` with optional date filter
+    - Implement `send_email` tool wrapping `emailTransport.sendMail()` with input validation and error handling
+    - Each tool is a thin adapter (10-20 lines) using Vercel AI SDK `tool()` and `zod` schemas
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6_
+
+  - [x] 3.2 Add `saveSummaryDirect()` method to `src/call-summary.js`
+    - Accept a pre-built summary object (callSid, callerPhone, twilioNumber, startTime, endTime, duration, summary, fullTranscript)
+    - Write it to disk as JSON in `call-summaries/` directory with the existing filename pattern
+    - Keep existing `saveCallSummary()` as fallback for when agent system is unavailable
+    - _Requirements: 1.1, 2.2, 2.6_
+
+  - [ ]* 3.3 Write property test for call summary save round trip
+    - **Property 1: Call summary save round trip**
+    - **Validates: Requirements 1.1**
+
+  - [ ]* 3.4 Write property test for provider profiles adapter transparency
+    - **Property 2: Provider profiles adapter transparency**
+    - **Validates: Requirements 1.2**
+
+  - [ ]* 3.5 Write property test for call summaries date filtering
+    - **Property 3: Call summaries date filtering and sort order**
+    - **Validates: Requirements 1.3**
+
+  - [ ]* 3.6 Write property test for send email input validation
+    - **Property 4: Send email tool validates inputs and handles transport errors**
+    - **Validates: Requirements 1.5, 1.6**
+
+- [x] 4. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 5. Implement post-call agent
+  - [x] 5.1 Create `src/agents/post-call-agent.js`
+    - Implement `runPostCallAgent(callData)` that reads prompt from `prompts/post-call-agent.txt` on each invocation
+    - Use Vercel AI SDK `generateText()` with `createOpenAI` pointed at OpenRouter
+    - Pass `save_call_summary`, `read_provider_profiles`, `send_email` tools
+    - Build user message containing callSid, from, to, startTime, endTime, and full conversation transcript
+    - Set `maxSteps: 10` for tool-calling loop
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.7_
+
+  - [x] 5.2 Create `prompts/post-call-agent.txt` prompt instructions
+    - Instructions to analyze transcript, generate concise summary, save via `save_call_summary` tool
+    - Instructions to use `read_provider_profiles` to look up provider contact info
+    - Default guidance for matching caller inquiries to providers by name, specialty, context
+    - Default guidance for composing notification emails with caller phone, timestamp, summary
+    - Instructions to skip email when SMTP not configured (tool returns error)
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+  - [ ]* 5.3 Write property test for post-call agent message completeness
+    - **Property 5: Post-call agent receives complete call data**
+    - **Validates: Requirements 2.1**
+
+  - [ ]* 5.4 Write property test for prompt fresh-read behavior
+    - **Property 6: Prompt files are read fresh from disk on each invocation**
+    - **Validates: Requirements 2.4, 3.5, 4.3, 5.5**
+
+  - [ ]* 5.5 Write property test for agent error transcript preservation
+    - **Property 7: Agent errors preserve call transcript**
+    - **Validates: Requirements 2.6**
+
+- [x] 6. Implement daily digest agent
+  - [x] 6.1 Create `src/agents/daily-digest-agent.js`
+    - Implement `runDailyDigestAgent(adminEmail)` that reads prompt from `prompts/daily-digest-agent.txt` on each invocation
+    - Use Vercel AI SDK `generateText()` with `createOpenAI` pointed at OpenRouter
+    - Pass `read_call_summaries`, `read_provider_profiles`, `send_email` tools
+    - Build user message with today's date and admin email address
+    - Set `maxSteps: 10` for tool-calling loop
+    - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+  - [x] 6.2 Create `prompts/daily-digest-agent.txt` prompt instructions
+    - Instructions to use `read_call_summaries` to retrieve today's calls
+    - Instructions to use `read_provider_profiles` to enrich digest with provider context
+    - Default guidance for composing digest: total call count, per-call details, mentioned providers, patterns
+    - Instructions to skip sending when no calls occurred
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
+
+  - [ ]* 6.3 Write property test for digest schedule hour configurability
+    - **Property 9: Digest schedule hour is configurable**
+    - **Validates: Requirements 4.7**
+
+- [x] 7. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 8. Shadow mode — run agent in parallel with existing flow
+  - [x] 8.1 Add shadow mode to `src/call-handler.js`
+    - Keep the existing `callSummary.saveCallSummary()` call unchanged (current flow still produces the real summary)
+    - After the existing save, also fire `runPostCallAgent()` asynchronously in shadow mode
+    - The agent saves its summary to a separate shadow file (e.g., `call-summaries/shadow-{timestamp}-{callSid}.json`)
+    - Log both summaries side-by-side for comparison (agent summary vs. existing summary)
+    - Agent errors in shadow mode are logged but never affect the existing flow
+    - _Requirements: 2.1, 2.5, 2.6_
+
+  - [x] 8.2 Add shadow mode to `src/realtime/relay-service.js`
+    - Same pattern: keep existing summary flow, also fire agent in shadow mode
+    - Agent saves to shadow file, log comparison
+    - _Requirements: 2.1, 2.5, 2.6_
+
+  - [x] 8.3 Add shadow mode flag to config
+    - Add `POST_CALL_AGENT_MODE` env var with values: `shadow` (default), `active`, `disabled`
+    - `shadow`: run both flows in parallel, agent saves to shadow files
+    - `active`: agent replaces existing flow (with fallback)
+    - `disabled`: existing flow only, no agent
+    - _Requirements: 2.1, 2.5_
+
+- [ ] 9. Checkpoint — validate shadow mode output
+  - Deploy with shadow mode enabled, make test calls, compare agent summaries vs. existing summaries
+  - Verify agent produces equivalent or better summaries
+  - Verify provider notification emails are correct (if SMTP configured)
+  - Ask the user to review shadow output before proceeding to cutover
+
+- [x] 10. Cutover — switch agent to active mode
+  - [x] 10.1 Modify `src/call-handler.js` for active mode
+    - When `POST_CALL_AGENT_MODE=active`, replace `callSummary.saveCallSummary()` with `runPostCallAgent()`
+    - Catch errors, log them, and fall back to saving a basic summary via existing `saveCallSummary()`
+    - Ensure call teardown is never blocked by agent errors
+    - _Requirements: 2.1, 2.2, 2.5, 2.6_
+
+  - [x] 10.2 Modify `src/realtime/relay-service.js` for active mode
+    - Same active mode pattern with fallback
+    - _Requirements: 2.1, 2.2, 2.5, 2.6_
+
+  - [x] 10.3 Clean up shadow mode artifacts
+    - Remove shadow file writing logic (no longer needed once active mode is validated)
+    - Keep the `POST_CALL_AGENT_MODE` config flag for `active`/`disabled` toggle
+    - _Requirements: 2.1, 2.5_
+
+  - [ ]* 10.4 Write unit tests for agent integration and fallback
+    - Test post-call agent is called with correct call data from both call-handler and relay-service
+    - Test fallback saves basic summary when agent throws
+    - Test call teardown is not blocked by agent errors
+    - Test mode switching (shadow/active/disabled)
+    - _Requirements: 2.1, 2.5, 2.6_
+
+- [x] 11. Add startup initialization and daily digest scheduling to server
+  - [x] 11.1 Modify `src/server.js` for notification system startup
+    - Import and call `emailTransport.initialize()` at startup
+    - Verify prompt files exist (`prompts/post-call-agent.txt`, `prompts/daily-digest-agent.txt`), log warnings for missing
+    - Log SMTP configuration status (enabled/disabled)
+    - Schedule daily digest using `node-cron` at configured hour if `ADMIN_EMAIL` is set
+    - Log scheduled digest time when enabled, log warning when `ADMIN_EMAIL` missing
+    - Wrap digest agent call in try/catch so errors don't affect other functionality
+    - Startup must not be blocked by notification system initialization
+    - _Requirements: 4.1, 4.5, 4.6, 4.7, 7.1, 7.2, 7.3, 7.4_
+
+  - [ ]* 11.2 Write unit tests for startup and scheduling
+    - Test daily digest is not scheduled when `ADMIN_EMAIL` is missing
+    - Test startup logs include notification system status messages
+    - Test digest scheduling uses configured hour
+    - _Requirements: 4.5, 4.7, 7.1, 7.2, 7.3_
+
+- [x] 12. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- All code uses CommonJS (`require`/`module.exports`) per project conventions
+- Mock `nodemailer`, `fs`, and AI SDK `generateText` in tests to avoid real API calls

--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -47,16 +47,31 @@
 
 **Decision:** Claude Sonnet. Contact info collection is non-negotiable — a lead without a phone number is worthless.
 
-### Issues Created
-- [#16](https://github.com/guyarie/Receptionist/issues/16) — Prompt externalization via `data/` folder override
-- [#17](https://github.com/guyarie/Receptionist/issues/17) — Regression test framework for pre-deployment validation
+### Issues & PRs
+
+| Issue | PR | Status | Description |
+|-------|-----|--------|-------------|
+| [#16](https://github.com/guyarie/Receptionist/issues/16) | [#18](https://github.com/guyarie/Receptionist/pull/18) | Awaiting review | Prompt externalization — `data/prompts/` overrides repo defaults |
+| [#17](https://github.com/guyarie/Receptionist/issues/17) | [#19](https://github.com/guyarie/Receptionist/pull/19) | Awaiting review | Regression test framework for pre-deployment validation |
+
+**PR #18 — Prompt Externalization:**
+- `resolvePromptPath()` checks `data/prompts/` first, falls back to `prompts/`
+- `savePrompt()` writes to `data/prompts/` (gitignored), never modifies repo files
+- Tested: override → fallback → save → admin UI source field — all pass
+
+**PR #19 — Regression Test Framework:**
+- Standalone runner: `node tests/regression/runner.js --url <your-server>`
+- 5 default scenarios (medical/office themed, generic for all users)
+- Configurable fields, keywords, thresholds via `data/tests/config.json` override
+- Markdown report with per-scenario and per-field breakdowns
+- CI-friendly: exit code 1 if below threshold
+- Live test against ChargeWizards production: **92% average, PASSED**
 
 ### Pending
 - Embed chat widget on chargewizards.com (Wix Custom Code)
 - Lead notification system (Telegram/email on qualified leads)
 - Voice channel activation (OpenAI Realtime)
 - Replace placeholder reviews on website with real Yelp/Google reviews
-- PR generic improvements to main (Issues #16, #17)
 
 ---
 

--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -47,32 +47,97 @@
 
 **Decision:** Claude Sonnet. Contact info collection is non-negotiable — a lead without a phone number is worthless.
 
-### Issues & PRs
-
-| Issue | PR | Status | Description |
-|-------|-----|--------|-------------|
-| [#16](https://github.com/guyarie/Receptionist/issues/16) | [#18](https://github.com/guyarie/Receptionist/pull/18) | Awaiting review | Prompt externalization — `data/prompts/` overrides repo defaults |
-| [#17](https://github.com/guyarie/Receptionist/issues/17) | [#19](https://github.com/guyarie/Receptionist/pull/19) | Awaiting review | Regression test framework for pre-deployment validation |
-
-**PR #18 — Prompt Externalization:**
-- `resolvePromptPath()` checks `data/prompts/` first, falls back to `prompts/`
-- `savePrompt()` writes to `data/prompts/` (gitignored), never modifies repo files
-- Tested: override → fallback → save → admin UI source field — all pass
-
-**PR #19 — Regression Test Framework:**
-- Standalone runner: `node tests/regression/runner.js --url <your-server>`
-- 5 default scenarios (medical/office themed, generic for all users)
-- Configurable fields, keywords, thresholds via `data/tests/config.json` override
-- Markdown report with per-scenario and per-field breakdowns
-- CI-friendly: exit code 1 if below threshold
-- Live test against ChargeWizards production: **92% average, PASSED**
+### Issues Created
+- [#16](https://github.com/guyarie/Receptionist/issues/16) — Prompt externalization via `data/` folder override
+- [#17](https://github.com/guyarie/Receptionist/issues/17) — Regression test framework for pre-deployment validation
 
 ### Pending
 - Embed chat widget on chargewizards.com (Wix Custom Code)
 - Lead notification system (Telegram/email on qualified leads)
 - Voice channel activation (OpenAI Realtime)
 - Replace placeholder reviews on website with real Yelp/Google reviews
+- PR generic improvements to main (Issues #16, #17)
 
 ---
 
-*Last updated: 2026-03-10*
+
+---
+
+## 2026-03-16 — Codebase Un-Fork + Major Feature Updates
+
+### Codebase Genericized (Issue #24)
+All business-specific references removed from `src/` and `public/`. The codebase is now fully generic — any business can deploy by setting `.env` variables:
+
+| Variable | Purpose |
+|---|---|
+| `BUSINESS_NAME` | Company name (greetings, admin UI) |
+| `OWNER_NAME` | Owner name (transfers, logs) |
+| `RECEPTIONIST_NAME` | AI receptionist name |
+| `OWNER_PHONE` | Transfer target phone number |
+| `PUBLIC_URL` | Production domain (lead alert links) |
+
+New template files added:
+- `.env.example` — all env vars documented
+- `prompts/system-prompt.example.txt` — generic prompt template
+- `prompts/greeting.example.txt` — generic greeting
+- `prompts/webchat-greeting.example.txt` — generic webchat greeting
+
+### Voice Calls — Lead Detection Fixed
+- Voice calls now trigger lead detection and Telegram alerts
+- Root cause: voice calls use OpenAI Realtime API via `relay-service.js`, which bypassed `call-handler.js` lead tracking
+- Fix: lead tracking + DB save added to `relay-service.js cleanup()`
+
+### SQLite Database
+- Customer records: name, email, city, address, vehicle, notes
+- Interactions table supports types: `call`, `chat`, `sms`, `email`
+- Returning caller lookup checks DB first, falls back to JSON file scanning
+- API: `GET /api/customers`, `GET /api/customers/:phone`
+
+### Email Sync Endpoint
+- `POST /api/email-sync` — receives email interaction data from external sources
+- Enables returning caller recognition for customers who also emailed
+- Protected by `LEADS_API_KEY`
+
+### Prompt Improvements
+- **Vendor/supplier handling** — 3 caller paths: customer (qualify), vendor/partner (take message), off-topic (2-strike exit)
+- **Language switching** — detects non-English callers and responds in their language
+- **Pacing rule** — pauses after initial qualifying to ask "do you have any questions?"
+- **Contact-before-photos** — ensures name + phone collected before requesting photo uploads
+
+### Returning Caller Recognition (Issue #21)
+- Looks up caller phone in SQLite DB
+- Injects customer context into system prompt (name, email, city, vehicle, previous interactions)
+- Personalizes greeting: "Hi [Name], good to hear from you again"
+- Skips re-asking for known info
+
+### Telegram Lead Alerts
+- Configurable via `TELEGRAM_THREAD_ID` for forum topic routing
+- Links use `PUBLIC_URL` env var (no longer hardcoded)
+- Alerts include admin link + full transcript link
+
+### Bug Fixes
+- Telegram link interpolation — template literal broken during genericization, fixed
+- Widget auto-focus guard on touch devices (Issue #20)
+- Transfer detection regex genericized
+- Call hangup detection working via Twilio API
+
+### Warm Transfer (Issue #23 — deployed, testing in progress)
+- Conference-based transfer with recording
+- Endpoints: `/transfer-to-owner`, `/transfer-fallback`, `/transfer-status`, `/recording-complete`
+- Transfer triggers defined in system prompt (7 categories)
+- Recordings saved to `/call-recordings/`
+
+### SMS Handler
+- `/incoming-sms` endpoint
+- Conversation history per phone number
+- Integrated with lead detection
+
+### Issues Filed
+- [#20](https://github.com/guyarie/Receptionist/issues/20) — Mobile widget fixes
+- [#21](https://github.com/guyarie/Receptionist/issues/21) — Returning caller recognition
+- [#23](https://github.com/guyarie/Receptionist/issues/23) — Post-interaction review pipeline
+- [#24](https://github.com/guyarie/Receptionist/issues/24) — Codebase un-forked, fully generic
+
+---
+
+*Last updated: 2026-03-16*

--- a/devdocs/POST-CALL-AGENT-TESTING.md
+++ b/devdocs/POST-CALL-AGENT-TESTING.md
@@ -1,0 +1,94 @@
+# Post-Call Agent Testing
+
+Test the post-call agent by replaying real (or hand-crafted) call transcripts through `runPostCallAgent` without placing actual phone calls. The agent's real tools still run (OpenRouter, provider profiles, email, etc.) — only the phone call itself is skipped.
+
+## Quick Start
+
+All commands are run from the project root (where `package.json` lives).
+
+```bash
+# Seed a fixture from an existing call summary
+node tests/simulated_call_bank/seed-fixture.js call-summaries/call-2026-03-15-12-50-31-CAc26ac1.json
+
+# Run all fixtures through the agent
+npx vitest run --config tests/integration/vitest.integration.config.js
+
+# Run a single fixture
+FIXTURE=fixture-6864105d.json npx vitest run --config tests/integration/vitest.integration.config.js
+```
+
+## Creating Fixtures
+
+### From a real call summary
+
+Every completed call writes a summary JSON to `call-summaries/`. Convert any of those into a test fixture:
+
+```bash
+node tests/simulated_call_bank/seed-fixture.js call-summaries/<filename>.json
+```
+
+This reads the summary, maps the fields to the format `runPostCallAgent` expects, and writes a fixture to `tests/simulated_call_bank/`.
+
+The seed utility handles both the older flat summary format and the newer nested format automatically.
+
+### By hand
+
+Create a JSON file in `tests/simulated_call_bank/` with this shape:
+
+```json
+{
+  "callSid": "CA00000000000000000000000000000000",
+  "from": "+15551234567",
+  "to": "+18005551234",
+  "startTime": "2026-03-15T10:00:00",
+  "endTime": "2026-03-15T10:05:00",
+  "conversationHistory": [
+    { "role": "assistant", "content": "Hello! How can I help you today?" },
+    { "role": "user", "content": "I'm looking for a therapist for my child." }
+  ]
+}
+```
+
+Required fields: `callSid`, `from`, `to`, `startTime`, `endTime`, `conversationHistory` (array of `{ role, content }`).
+
+## Running the Tests
+
+Integration tests are excluded from the default `npx vitest run` because they hit real OpenRouter. Run them explicitly:
+
+```bash
+# All fixtures
+npx vitest run --config tests/integration/vitest.integration.config.js
+
+# Single fixture
+FIXTURE=fixture-6864105d.json npx vitest run --config tests/integration/vitest.integration.config.js
+```
+
+Each fixture gets a 120-second timeout. The test reports which tools the agent called and whether it completed successfully.
+
+## What Happens During a Test Run
+
+1. The loader reads and validates all `.json` files from `tests/simulated_call_bank/`
+2. For each fixture, `runPostCallAgent(fixtureData)` is called
+3. The agent runs its full loop — reads provider profiles, generates a summary, may send emails
+4. Agent debug logs are written to `data/agent_logs/`
+5. The test reports pass/fail and tool calls for each fixture
+
+## Typical Workflow
+
+1. A bug is reported with a specific call
+2. Find the call summary in `call-summaries/`
+3. Seed it: `node tests/simulated_call_bank/seed-fixture.js call-summaries/<file>.json`
+4. Run it: `FIXTURE=fixture-<sid>.json npx vitest run tests/integration/post-call-agent.test.js`
+5. Check `data/agent_logs/` for the detailed agent trace
+6. Fix the issue, re-run to verify
+
+## File Locations
+
+| What | Where |
+|------|-------|
+| Fixtures | `tests/simulated_call_bank/*.json` |
+| Seed utility | `tests/simulated_call_bank/seed-fixture.js` |
+| Fixture loader | `tests/simulated_call_bank/loader.js` |
+| Integration test | `tests/integration/post-call-agent.test.js` |
+| Agent debug logs | `data/agent_logs/` |
+| Call summaries (input) | `call-summaries/` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,21 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@ai-sdk/openai": "^3.0.41",
+        "ai": "^6.0.116",
         "axios": "^1.13.5",
         "cheerio": "^1.2.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.6",
         "dotenv": "^17.2.4",
         "express": "^5.2.1",
+        "node-cron": "^4.2.1",
+        "nodemailer": "^8.0.2",
         "openai": "^6.18.0",
         "puppeteer": "^24.37.5",
         "twilio": "^5.12.1",
-        "ws": "^8.19.0"
+        "ws": "^8.19.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "fast-check": "^4.5.3",
@@ -33,6 +38,68 @@
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.66",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.66.tgz",
+      "integrity": "sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.19",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.41",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.41.tgz",
+      "integrity": "sha512-IZ42A+FO+vuEQCVNqlnAPYQnnUpUfdJIwn1BEDOBywiEHa23fw7PahxVtlX9zm3/zMvTW4JKPzWyvAgDu+SQ2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.19"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.19.tgz",
+      "integrity": "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.0.1",
@@ -740,6 +807,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -1125,7 +1201,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -1177,6 +1252,15 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1313,6 +1397,24 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.116",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.116.tgz",
+      "integrity": "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.66",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.19",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ansi-regex": {
@@ -1671,6 +1773,15 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/cliui": {
@@ -2378,6 +2489,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expect-type": {
@@ -3088,6 +3208,12 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
@@ -3330,6 +3456,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.2.tgz",
+      "integrity": "sha512-zbj002pZAIkWQFxyAaqoxvn+zoIwRnS40hgjqTXudKOOJkiFFgBeNqjgD3/YCR12sZnrghWYBY+yP1ZucdDRpw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nth-check": {
@@ -4848,9 +4992,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -16,16 +16,21 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.41",
+    "ai": "^6.0.116",
     "axios": "^1.13.5",
     "cheerio": "^1.2.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
     "dotenv": "^17.2.4",
     "express": "^5.2.1",
+    "node-cron": "^4.2.1",
+    "nodemailer": "^8.0.2",
     "openai": "^6.18.0",
     "puppeteer": "^24.37.5",
     "twilio": "^5.12.1",
-    "ws": "^8.19.0"
+    "ws": "^8.19.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "fast-check": "^4.5.3",

--- a/prompts/daily-digest-agent.txt
+++ b/prompts/daily-digest-agent.txt
@@ -1,0 +1,44 @@
+You are the daily digest agent for the Relational Therapy Collective (RTC), a therapy practice in Bellevue, WA.
+
+Your job is to compose and send a daily summary email to the practice administrator covering all phone calls received today.
+
+STEPS:
+
+1. READ TODAY'S CALLS
+   - Use the `read_call_summaries` tool with today's date (provided in the user message) to get all call summaries for the day
+   - If there are no calls for today, do NOT send an email — just stop
+
+2. ENRICH WITH PROVIDER CONTEXT
+   - Use the `read_provider_profiles` tool to look up provider details
+   - Cross-reference any providers mentioned in call summaries with their profiles
+   - Note which providers were recommended or requested by callers
+
+3. COMPOSE THE DIGEST EMAIL
+   Structure the email as follows:
+
+   Subject: "RTC Daily Call Digest — [date] ([N] calls)"
+
+   Body:
+   - Opening line with total call count
+   - For each call, include:
+     - Time of call
+     - Caller phone number
+     - Brief summary of what the caller needed
+     - Provider(s) mentioned or recommended (if any)
+     - Duration
+   - A "Patterns & Notes" section at the end if you notice:
+     - Multiple callers asking about the same provider
+     - Common themes (e.g., several anxiety-related inquiries)
+     - Any calls that seem to need follow-up attention
+   - Keep the tone professional but readable — this is a quick daily briefing
+
+4. SEND THE EMAIL
+   - Use the `send_email` tool to send the digest to the admin email address (provided in the user message)
+   - If the send_email tool returns an error, do not retry — just stop
+
+GUIDELINES:
+- Keep the digest concise and scannable
+- Use plain text formatting (no HTML)
+- List calls in chronological order
+- If a call had no meaningful conversation (very short, no speech detected), mention it briefly but don't elaborate
+- Do not include full transcripts — summaries only

--- a/prompts/post-call-agent.txt
+++ b/prompts/post-call-agent.txt
@@ -1,40 +1,14 @@
-You are the post-call processing agent for the Relational Therapy Collective (RTC), a therapy practice in Bellevue, WA.
+You are the post-call processing agent. A phone call has just ended. You will receive the call metadata and full conversation transcript.
 
-A phone call has just ended. You will receive the call metadata and full conversation transcript.
+Your job is to generate a summary and save it. Do not send any emails or notifications.
 
 Follow these steps IN ORDER:
 
 1. ANALYZE THE TRANSCRIPT
    - Read the conversation carefully
-   - Identify: what the caller wanted, which providers were mentioned, any next steps
-   - Note the caller's name if provided
+   - Identify: what the caller was looking for, what information was provided, any specific clinicians or providers mentioned, and next steps or action items
 
-2. DECIDE WHETHER TO NOTIFY A PROVIDER
-   - Use the `read_provider_profiles` tool to look up provider email addresses
-   - You MUST send a notification email using the `send_email` tool if ANY of these apply:
-     - A specific provider was mentioned by name in the conversation
-     - The caller was matched to or recommended a specific provider
-     - The caller expressed intent to schedule with a specific provider
-   - Do NOT send email if:
-     - The call was a general inquiry with no specific provider match
-     - The caller hung up quickly or no meaningful conversation occurred
-   - If the `send_email` tool returns an error (e.g. SMTP not configured), note it and move on
-
-3. ACTUALLY SEND THE EMAIL (if applicable)
-   You must call the `send_email` tool — do not just describe what you would send.
-   - Send to: {{ADMIN_EMAIL}}
-   - Subject: "Caller inquiry — [provider name]"
-   - Body should include:
-     - Caller's phone number
-     - Brief topic (what the caller was looking for)
-     - Provider's email address (from their profile) for easy forwarding
-     - Date and time of the call
-     - A brief summary of the caller's needs
-     - Any relevant details the provider should know before following up
-   - Keep the tone professional and concise
-   - Do not include the full transcript in the email
-
-4. SAVE THE CALL SUMMARY
+2. SAVE THE CALL SUMMARY
    Call the `save_call_summary` tool with these FLAT top-level parameters (do NOT nest them inside another object):
    - callSid: from the call metadata
    - callerPhone: the caller's phone number
@@ -42,14 +16,10 @@ Follow these steps IN ORDER:
    - startTime: from the call metadata
    - endTime: from the call metadata
    - duration: difference between endTime and startTime in seconds (e.g. "93 seconds")
-   - summary: a concise 3-5 sentence summary covering what the caller wanted, what was discussed, providers mentioned, and next steps
+   - summary: a concise 3-4 sentence summary covering: what the caller was looking for, what information was provided, any specific clinicians mentioned, and next steps or action items
    - fullTranscript: array of {speaker, message} pairs — use "Caller" and "AI Receptionist" as speaker names
-   - notificationDecision: a brief explanation of what you decided about notifications and why (e.g. "Sent notification about Claire de Leon — caller seeking child anxiety therapy" or "No notification — caller hung up before any provider was discussed")
+   - notificationDecision: "No notification sent — default summary-only mode"
 
    CRITICAL: Pass each field as a separate parameter to the tool. For example:
    save_call_summary(callSid="CA123...", callerPhone="+1234567890", summary="...", ...)
    Do NOT wrap them in a nested object like save_call_summary(summary={callSid: ..., ...})
-
-IMPORTANT:
-- If the send_email tool returns an error, note it in notificationDecision and move on — do not retry
-- Focus on accuracy — get the summary and provider matching right

--- a/prompts/post-call-agent.txt
+++ b/prompts/post-call-agent.txt
@@ -1,0 +1,55 @@
+You are the post-call processing agent for the Relational Therapy Collective (RTC), a therapy practice in Bellevue, WA.
+
+A phone call has just ended. You will receive the call metadata and full conversation transcript.
+
+Follow these steps IN ORDER:
+
+1. ANALYZE THE TRANSCRIPT
+   - Read the conversation carefully
+   - Identify: what the caller wanted, which providers were mentioned, any next steps
+   - Note the caller's name if provided
+
+2. DECIDE WHETHER TO NOTIFY A PROVIDER
+   - Use the `read_provider_profiles` tool to look up provider email addresses
+   - You MUST send a notification email using the `send_email` tool if ANY of these apply:
+     - A specific provider was mentioned by name in the conversation
+     - The caller was matched to or recommended a specific provider
+     - The caller expressed intent to schedule with a specific provider
+   - Do NOT send email if:
+     - The call was a general inquiry with no specific provider match
+     - The caller hung up quickly or no meaningful conversation occurred
+   - If the `send_email` tool returns an error (e.g. SMTP not configured), note it and move on
+
+3. ACTUALLY SEND THE EMAIL (if applicable)
+   You must call the `send_email` tool — do not just describe what you would send.
+   - Send to: {{ADMIN_EMAIL}}
+   - Subject: "Caller inquiry — [provider name]"
+   - Body should include:
+     - Caller's phone number
+     - Brief topic (what the caller was looking for)
+     - Provider's email address (from their profile) for easy forwarding
+     - Date and time of the call
+     - A brief summary of the caller's needs
+     - Any relevant details the provider should know before following up
+   - Keep the tone professional and concise
+   - Do not include the full transcript in the email
+
+4. SAVE THE CALL SUMMARY
+   Call the `save_call_summary` tool with these FLAT top-level parameters (do NOT nest them inside another object):
+   - callSid: from the call metadata
+   - callerPhone: the caller's phone number
+   - twilioNumber: the Twilio number that received the call
+   - startTime: from the call metadata
+   - endTime: from the call metadata
+   - duration: difference between endTime and startTime in seconds (e.g. "93 seconds")
+   - summary: a concise 3-5 sentence summary covering what the caller wanted, what was discussed, providers mentioned, and next steps
+   - fullTranscript: array of {speaker, message} pairs — use "Caller" and "AI Receptionist" as speaker names
+   - notificationDecision: a brief explanation of what you decided about notifications and why (e.g. "Sent notification about Claire de Leon — caller seeking child anxiety therapy" or "No notification — caller hung up before any provider was discussed")
+
+   CRITICAL: Pass each field as a separate parameter to the tool. For example:
+   save_call_summary(callSid="CA123...", callerPhone="+1234567890", summary="...", ...)
+   Do NOT wrap them in a nested object like save_call_summary(summary={callSid: ..., ...})
+
+IMPORTANT:
+- If the send_email tool returns an error, note it in notificationDecision and move on — do not retry
+- Focus on accuracy — get the summary and provider matching right

--- a/prompts/system-prompt.txt
+++ b/prompts/system-prompt.txt
@@ -17,6 +17,13 @@ If this is an emergency, please hang up and dial 911.
 I'm your AI receptionist. This call will be transcribed for quality assurance purposes.
 How can I help you today?
 - Use the practice information below to answer questions - do NOT make up information
+- When a caller is looking for a therapist, always ask these questions BEFORE making any recommendation:
+  1. Who is therapy for? (themselves / a child / a couple / a family)
+  2. If for a child — what age?
+  3. What are the main concerns or reasons for reaching out?
+  Then optionally: any preference for in-person or telehealth? Insurance or self-pay? Language preference?
+- When matching callers to providers, follow the PROVIDER MATCHING GUIDE below strictly — including who is NOT ACCEPTING new clients.
+- Always recommend 2 providers when possible, with a one-sentence explanation of why each is a good fit. Never default to the same provider repeatedly.
 - If the caller mentions a specific specialty or concern, and there are clinicians who specialize in that area, mention them and offer to provide their contact details
 - When mentioning clinicians, use their names and specialties from the information provided
 - At the earliest opportunity - after answering the caller's priorities and direct questions, ask them for their name 
@@ -35,6 +42,6 @@ CONTACT INFORMATION:
 - Note: The main phone number is for inquiries only, not for scheduling appointments. 
 
 
-Important: You are a receptionist, not a general assistant. 
-If you are asked about anything that is not something a receptionist should be asked for, 
+Important: You are a receptionist, not a general assistant.
+If you are asked about anything that is not something a receptionist should be asked for,
 advise the user that you cannot support this request.

--- a/public/admin/calls.html
+++ b/public/admin/calls.html
@@ -21,7 +21,10 @@
 
   <div class="container">
     <div class="card">
-      <h2>Call History</h2>
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+        <h2 style="margin-bottom: 0;">Call History</h2>
+        <button id="deleteAllBtn" class="btn btn-danger btn-sm" onclick="deleteAllCalls()">🗑️ Delete All</button>
+      </div>
       <div id="callsContainer">
         <div class="spinner"></div>
       </div>
@@ -82,6 +85,7 @@
                     <span class="expand-toggle" onclick="toggleTranscript('${UI.escapeHtml(call.id)}')">
                       View Details
                     </span>
+                    <button class="btn btn-danger btn-sm" style="margin-left: 0.5rem; padding: 0.25rem 0.5rem; font-size: 0.8rem;" onclick="deleteSingleCall('${UI.escapeHtml(call.id)}', this)" title="Delete this call log">🗑️</button>
                   </td>
                 </tr>
                 <tr id="transcript-${UI.escapeHtml(call.id)}" class="hidden">
@@ -186,9 +190,57 @@
       pagination.innerHTML = buttons.join('');
     }
 
+    // Delete a single call log
+    async function deleteSingleCall(callId, buttonEl) {
+      if (!confirm('Are you sure you want to delete this call log? This action cannot be undone.')) {
+        return;
+      }
+
+      try {
+        await UI.apiFetch(`/admin/api/calls/${encodeURIComponent(callId)}`, { method: 'DELETE' });
+
+        // Remove the call row and its transcript row from the DOM
+        const transcriptRow = document.getElementById(`transcript-${callId}`);
+        if (transcriptRow) {
+          transcriptRow.previousElementSibling.remove();
+          transcriptRow.remove();
+        } else {
+          // Fallback: walk up from the button to the <tr>
+          const row = buttonEl.closest('tr');
+          if (row) row.remove();
+        }
+
+        UI.Toast.success('Call log deleted successfully');
+      } catch (error) {
+        UI.Toast.error('Failed to delete call log: ' + error.message);
+      }
+    }
+
+    // Delete all call logs
+    async function deleteAllCalls() {
+      if (!confirm('Are you sure you want to delete ALL call logs? This action cannot be undone.')) {
+        return;
+      }
+
+      const deleteAllBtn = document.getElementById('deleteAllBtn');
+      deleteAllBtn.disabled = true;
+
+      try {
+        const data = await UI.apiFetch('/admin/api/calls', { method: 'DELETE' });
+        UI.Toast.success(`Deleted ${data.deletedCount} call log(s)`);
+        loadCalls(1);
+      } catch (error) {
+        UI.Toast.error('Failed to delete call logs: ' + error.message);
+      } finally {
+        deleteAllBtn.disabled = false;
+      }
+    }
+
     // Make functions available globally
     window.toggleTranscript = toggleTranscript;
     window.loadCalls = loadCalls;
+    window.deleteSingleCall = deleteSingleCall;
+    window.deleteAllCalls = deleteAllCalls;
 
     // Load calls on page load
     loadCalls(1);

--- a/public/embed-chat.html
+++ b/public/embed-chat.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chat with us</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      background: transparent;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .chat-header {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 16px 20px;
+    }
+
+    .chat-header h1 {
+      font-size: 18px;
+      margin-bottom: 2px;
+    }
+
+    .chat-header p {
+      font-size: 13px;
+      opacity: 0.9;
+    }
+
+    .chat-messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 20px;
+      background: #f7f7f7;
+    }
+
+    .message {
+      margin-bottom: 15px;
+      display: flex;
+      align-items: flex-start;
+    }
+
+    .message.user {
+      justify-content: flex-end;
+    }
+
+    .message-content {
+      max-width: 80%;
+      padding: 12px 16px;
+      border-radius: 18px;
+      line-height: 1.4;
+      font-size: 14px;
+    }
+
+    .message.ai .message-content {
+      background: white;
+      color: #333;
+      border-bottom-left-radius: 4px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+
+    .message.user .message-content {
+      background: #667eea;
+      color: white;
+      border-bottom-right-radius: 4px;
+    }
+
+    .chat-input-container {
+      padding: 14px 16px;
+      background: white;
+      border-top: 1px solid #e0e0e0;
+    }
+
+    .chat-input-form {
+      display: flex;
+      gap: 8px;
+    }
+
+    .chat-input {
+      flex: 1;
+      padding: 10px 16px;
+      border: 2px solid #e0e0e0;
+      border-radius: 24px;
+      font-size: 14px;
+      outline: none;
+      transition: border-color 0.3s;
+    }
+
+    .chat-input:focus {
+      border-color: #667eea;
+    }
+
+    .chat-send-btn {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 24px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.2s;
+    }
+
+    .chat-send-btn:hover {
+      opacity: 0.9;
+    }
+
+    .chat-send-btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .typing-indicator {
+      display: none;
+      padding: 12px 16px;
+      background: white;
+      border-radius: 18px;
+      border-bottom-left-radius: 4px;
+      max-width: 70px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+
+    .typing-indicator.active {
+      display: block;
+    }
+
+    .typing-indicator span {
+      height: 8px;
+      width: 8px;
+      background: #999;
+      border-radius: 50%;
+      display: inline-block;
+      margin-right: 4px;
+      animation: typing 1.4s infinite;
+    }
+
+    .typing-indicator span:nth-child(2) { animation-delay: 0.2s; }
+    .typing-indicator span:nth-child(3) { animation-delay: 0.4s; }
+
+    @keyframes typing {
+      0%, 60%, 100% { transform: translateY(0); }
+      30% { transform: translateY(-8px); }
+    }
+  </style>
+</head>
+<body>
+  <div class="chat-header">
+    <h1>Chat with us</h1>
+    <p>Relational Therapy Collective</p>
+  </div>
+
+  <div class="chat-messages" id="messages"></div>
+
+  <div class="chat-input-container">
+    <form class="chat-input-form" id="chatForm">
+      <input
+        type="text"
+        class="chat-input"
+        id="messageInput"
+        placeholder="Type your message..."
+        autocomplete="off"
+      >
+      <button type="submit" class="chat-send-btn" id="sendBtn">Send</button>
+    </form>
+  </div>
+
+  <script>
+    const messagesContainer = document.getElementById('messages');
+    const chatForm = document.getElementById('chatForm');
+    const messageInput = document.getElementById('messageInput');
+    const sendBtn = document.getElementById('sendBtn');
+
+    // Determine API base URL (same origin as this page)
+    const API_BASE = window.location.origin;
+
+    // Session and conversation state
+    let sessionId = 'embed-' + crypto.randomUUID();
+    let conversationHistory = [];
+
+    // Load greeting on page load
+    async function loadGreeting() {
+      try {
+        const response = await fetch(API_BASE + '/api/greeting');
+        const data = await response.json();
+        addMessage('ai', data.greeting);
+      } catch (error) {
+        addMessage('ai', 'Hello! How can I help you today?');
+      }
+    }
+
+    loadGreeting();
+
+    chatForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const message = messageInput.value.trim();
+      if (!message) return;
+
+      addMessage('user', message);
+      messageInput.value = '';
+
+      // Add to conversation history
+      conversationHistory.push({ role: 'user', content: message });
+
+      const typingIndicator = addTypingIndicator();
+      messageInput.disabled = true;
+      sendBtn.disabled = true;
+
+      try {
+        const response = await fetch(API_BASE + '/api/webchat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId: sessionId,
+            messages: conversationHistory
+          })
+        });
+
+        const data = await response.json();
+        typingIndicator.remove();
+
+        // Add AI response to history and display
+        conversationHistory.push({ role: 'assistant', content: data.response });
+        addMessage('ai', data.response);
+
+      } catch (error) {
+        typingIndicator.remove();
+        addMessage('ai', 'Sorry, I encountered an error. Please try again.');
+      }
+
+      messageInput.disabled = false;
+      sendBtn.disabled = false;
+      messageInput.focus();
+    });
+
+    function addMessage(type, content) {
+      const messageDiv = document.createElement('div');
+      messageDiv.className = 'message ' + type;
+
+      const bubble = document.createElement('div');
+      bubble.className = 'message-content';
+      bubble.textContent = content;
+
+      messageDiv.appendChild(bubble);
+      messagesContainer.appendChild(messageDiv);
+      messagesContainer.scrollTop = messagesContainer.scrollHeight;
+    }
+
+    function addTypingIndicator() {
+      const typingDiv = document.createElement('div');
+      typingDiv.className = 'message ai';
+      typingDiv.innerHTML = '<div class="typing-indicator active"><span></span><span></span><span></span></div>';
+      messagesContainer.appendChild(typingDiv);
+      messagesContainer.scrollTop = messagesContainer.scrollHeight;
+      return typingDiv;
+    }
+
+    messageInput.focus();
+  </script>
+</body>
+</html>

--- a/src/agents/daily-digest-agent.js
+++ b/src/agents/daily-digest-agent.js
@@ -1,0 +1,48 @@
+// Daily Digest Agent — runs on a cron schedule to send daily call digest
+// Reads prompt from disk, uses Vercel AI SDK to compose and send digest email
+const fs = require('fs');
+const path = require('path');
+const { generateText } = require('ai');
+const { createOpenAI } = require('@ai-sdk/openai');
+const config = require('../config');
+const { createTools } = require('./tools');
+
+const PROMPT_PATH = path.join(__dirname, '..', '..', 'prompts', 'daily-digest-agent.txt');
+
+async function runDailyDigestAgent(adminEmail) {
+  // Read prompt from disk on each invocation (no caching)
+  let promptInstructions;
+  try {
+    promptInstructions = fs.readFileSync(PROMPT_PATH, 'utf-8').trim();
+  } catch (err) {
+    console.error('❌ Failed to read daily digest agent prompt:', err.message);
+    throw err;
+  }
+
+  const openai = createOpenAI({
+    baseURL: 'https://openrouter.ai/api/v1',
+    apiKey: config.openRouter.apiKey,
+  });
+
+  const tools = createTools();
+
+  const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+
+  const userMessage = `It is now time to generate the daily digest.
+Today's date: ${today}
+Admin email: ${adminEmail}
+
+Please read today's call summaries, review them, and compose a digest email to send to the admin.`;
+
+  const result = await generateText({
+    model: openai(config.openRouter.model),
+    system: promptInstructions,
+    prompt: userMessage,
+    tools,
+    maxSteps: 10,
+  });
+
+  return result;
+}
+
+module.exports = { runDailyDigestAgent };

--- a/src/agents/post-call-agent.js
+++ b/src/agents/post-call-agent.js
@@ -1,0 +1,159 @@
+// Post-Call Agent — runs after each call ends
+// Reads prompt from disk, uses Vercel AI SDK to generate summary and notify providers
+// Uses manual tool loop because OpenRouter + AI SDK maxSteps doesn't reliably
+// continue after tool calls.
+const fs = require('fs');
+const path = require('path');
+const { generateText } = require('ai');
+const { createOpenAI } = require('@ai-sdk/openai');
+const config = require('../config');
+const { createTools } = require('./tools');
+const { getFilenameSafeTimestamp } = require('../time-utils');
+
+const PROMPT_PATH = path.join(__dirname, '..', '..', 'prompts', 'post-call-agent.txt');
+const LOGS_DIR = path.join(__dirname, '..', '..', 'data', 'agent_logs');
+const MAX_ITERATIONS = 10;
+
+function ensureLogsDir() {
+  if (!fs.existsSync(LOGS_DIR)) {
+    fs.mkdirSync(LOGS_DIR, { recursive: true });
+  }
+}
+
+function saveAgentLog(callSid, logData) {
+  try {
+    ensureLogsDir();
+    const timestamp = getFilenameSafeTimestamp();
+    const shortSid = callSid ? callSid.substring(0, 8) : 'unknown';
+    const filename = `agent-${timestamp}-${shortSid}.json`;
+    const filepath = path.join(LOGS_DIR, filename);
+    fs.writeFileSync(filepath, JSON.stringify(logData, null, 2));
+    console.log(`🔍 Agent debug log saved: ${filename}`);
+  } catch (err) {
+    console.error('⚠️ Failed to save agent log:', err.message);
+  }
+}
+
+async function runPostCallAgent(callData) {
+  let promptInstructions;
+  try {
+    promptInstructions = fs.readFileSync(PROMPT_PATH, 'utf-8').trim();
+  } catch (err) {
+    console.error('❌ Failed to read post-call agent prompt:', err.message);
+    throw err;
+  }
+
+  // Inject config values into prompt template
+  const adminEmail = process.env.ADMIN_EMAIL || 'admin@example.com';
+  promptInstructions = promptInstructions.replace('{{ADMIN_EMAIL}}', adminEmail);
+
+  const openai = createOpenAI({
+    baseURL: 'https://openrouter.ai/api/v1',
+    apiKey: config.openRouter.apiKey,
+  });
+
+  const tools = createTools();
+  // Use .chat() to force Chat Completions API — OpenRouter doesn't support the Responses API
+  // which is the default in @ai-sdk/openai v3+ / AI SDK 5+
+  const model = openai.chat(config.openRouter.model);
+
+  const userMessage = `Call has ended. Here is the call data:
+
+Call SID: ${callData.callSid}
+Caller Phone: ${callData.from}
+Twilio Number: ${callData.to}
+Start Time: ${callData.startTime}
+End Time: ${callData.endTime}
+
+Conversation Transcript:
+${callData.conversationHistory.map(m =>
+    `${m.role === 'user' ? 'Caller' : 'AI Receptionist'}: ${m.content}`
+  ).join('\n')}`;
+
+  // Manual tool loop — OpenRouter doesn't reliably support maxSteps > 1
+  const messages = [
+    { role: 'system', content: promptInstructions },
+    { role: 'user', content: userMessage }
+  ];
+
+  const startTime = Date.now();
+  const logSteps = [];
+  let iteration = 0;
+  let lastResult = null;
+
+  while (iteration < MAX_ITERATIONS) {
+    iteration++;
+    console.log(`🤖 Agent iteration ${iteration}...`);
+
+    const result = await generateText({
+      model,
+      messages,
+      tools,
+      maxSteps: 1,
+    });
+
+    const stepLog = { iteration };
+    const toolCalls = result.toolCalls || [];
+    const toolResults = result.toolResults || [];
+
+    if (toolCalls.length > 0) {
+      stepLog.toolCalls = toolCalls.map(tc => ({ tool: tc.toolName, args: tc.args }));
+      stepLog.toolResults = toolResults.map(tr => ({
+        tool: tr.toolName,
+        result: typeof tr.result === 'string' ? tr.result : String(JSON.stringify(tr.result) || '').substring(0, 500)
+      }));
+      console.log(`   Iteration ${iteration}: called ${toolCalls.map(tc => tc.toolName).join(', ')}`);
+
+      // Append the SDK-formatted response messages (assistant + tool results)
+      // Strip providerOptions/providerMetadata that OpenRouter doesn't understand
+      if (result.response && result.response.messages) {
+        for (const msg of result.response.messages) {
+          const clean = { role: msg.role };
+          if (Array.isArray(msg.content)) {
+            clean.content = msg.content.map(part => {
+              const { providerOptions, providerMetadata, ...rest } = part;
+              return rest;
+            });
+          } else {
+            clean.content = msg.content;
+          }
+          messages.push(clean);
+        }
+      }
+    }
+
+    if (result.text) {
+      stepLog.text = result.text;
+    }
+    stepLog.finishReason = result.finishReason;
+    stepLog.usage = result.usage || null;
+    logSteps.push(stepLog);
+
+    lastResult = result;
+
+    // If the model finished without requesting more tool calls, we're done
+    if (result.finishReason === 'stop' || result.finishReason === 'end-turn' || toolCalls.length === 0) {
+      console.log(`   Iteration ${iteration}: done (${result.finishReason})`);
+      break;
+    }
+  }
+
+  const elapsed = Date.now() - startTime;
+  console.log(`🤖 Agent completed: ${iteration} iterations in ${elapsed}ms`);
+
+  // Save debug log
+  const logData = {
+    callSid: callData.callSid,
+    callerPhone: callData.from,
+    timestamp: new Date().toISOString(),
+    model: config.openRouter.model,
+    elapsedMs: elapsed,
+    totalIterations: iteration,
+    steps: logSteps
+  };
+  saveAgentLog(callData.callSid, logData);
+
+  return lastResult;
+}
+
+module.exports = { runPostCallAgent };

--- a/src/agents/tools.js
+++ b/src/agents/tools.js
@@ -1,0 +1,104 @@
+// Shared tool definitions for AI agents
+// Each tool is a thin adapter wrapping an existing module
+const { tool } = require('ai');
+const { z } = require('zod');
+const callSummaryManager = require('../call-summary');
+const providerLoader = require('../provider-loader');
+const emailTransport = require('../email-transport');
+
+function createTools(options = {}) {
+  const tools = {
+    save_call_summary: tool({
+      description: 'Save a call summary to disk as a JSON file',
+      parameters: z.object({
+        callSid: z.string(),
+        callerPhone: z.string(),
+        twilioNumber: z.string(),
+        startTime: z.string(),
+        endTime: z.string(),
+        duration: z.string(),
+        summary: z.string(),
+        fullTranscript: z.array(z.object({
+          speaker: z.string(),
+          message: z.string()
+        })),
+        notificationDecision: z.string().optional().describe('Brief explanation of whether a notification was sent and why')
+      }),
+      execute: async (params) => {
+        const filepath = callSummaryManager.saveSummaryDirect(params);
+        return { success: true, filepath };
+      }
+    }),
+
+    read_provider_profiles: tool({
+      description: 'Read compact provider profiles: name, email, specialties, insurance accepted',
+      parameters: z.object({}),
+      execute: async () => {
+        const allProfiles = providerLoader.getAll();
+        // Extract compact info from each markdown profile to keep token count low
+        const compact = {};
+        for (const [filename, content] of Object.entries(allProfiles)) {
+          const name = (content.match(/^#\s+(.+)/m) || [])[1] || filename.replace('.md', '');
+          const email = (content.match(/\*\*Email:\*\*\s*(.+)/i) || [])[1] || 'not listed';
+          const phone = (content.match(/\*\*Phone:\*\*\s*(.+)/i) || [])[1] || 'not listed';
+
+          // Extract areas of focus / specialties section
+          const focusMatch = content.match(/## Areas of Focus\n([\s\S]*?)(?=\n##|\n$|$)/);
+          const specialties = focusMatch
+            ? focusMatch[1].split('\n').filter(l => l.startsWith('- ')).map(l => l.replace(/^- /, '').trim()).join(', ')
+            : '';
+
+          // Extract insurance section if present
+          const insuranceMatch = content.match(/## Insurance.*?\n([\s\S]*?)(?=\n##|\n$|$)/i);
+          const insurance = insuranceMatch
+            ? insuranceMatch[1].split('\n').filter(l => l.startsWith('- ')).map(l => l.replace(/^- /, '').trim()).join(', ')
+            : 'not listed';
+
+          compact[filename] = { name, email, phone, specialties, insurance };
+        }
+        return compact;
+      }
+    }),
+
+    read_call_summaries: tool({
+      description: 'Read call summaries, optionally filtered by date',
+      parameters: z.object({
+        date: z.string().optional().describe('ISO date string (YYYY-MM-DD) to filter summaries')
+      }),
+      execute: async ({ date }) => {
+        const summaries = callSummaryManager.getAllSummaries();
+        if (date) {
+          return summaries.filter(s => s.startTime && s.startTime.startsWith(date));
+        }
+        return summaries;
+      }
+    }),
+
+    send_email: tool({
+      description: 'Send an email to a recipient',
+      parameters: z.object({
+        to: z.string().describe('Recipient email address'),
+        subject: z.string().describe('Email subject line'),
+        body: z.string().describe('Email body text')
+      }),
+      execute: async ({ to, subject, body }) => {
+        if (!to || to.trim() === '') {
+          return { success: false, error: 'Recipient email address is missing or empty' };
+        }
+        if (!emailTransport.isConfigured()) {
+          return { success: false, error: 'Email is not configured (SMTP settings missing)' };
+        }
+        try {
+          await emailTransport.sendMail({ to, subject, body });
+          return { success: true };
+        } catch (err) {
+          return { success: false, error: `Failed to send email: ${err.message}` };
+        }
+      }
+    })
+  };
+
+  return tools;
+}
+
+module.exports = { createTools };

--- a/src/call-handler.js
+++ b/src/call-handler.js
@@ -1,7 +1,9 @@
 // Call Handler - Manages individual call sessions
 const aiClient = require('./ai-client');
 const callSummary = require('./call-summary');
+const config = require('./config');
 const { getPacificTimeISO } = require('./time-utils');
+const { runPostCallAgent } = require('./agents/post-call-agent');
 
 class CallHandler {
   constructor() {
@@ -71,25 +73,42 @@ class CallHandler {
   async endCall(callSid) {
     const session = this.activeCalls.get(callSid);
     if (session) {
-      try {
-        // Get conversation history
-        const conversationHistory = aiClient.getHistory(callSid);
-        
-        // Save call summary
-        await callSummary.saveCallSummary({
-          callSid: session.callSid,
-          from: session.from,
-          to: session.to,
-          startTime: session.startTime,
-          endTime: getPacificTimeISO(),
-          conversationHistory: conversationHistory
-        });
-        
-        console.log(`📞 Call ended: ${callSid} - Summary saved`);
-      } catch (error) {
-        console.error('❌ Error saving call summary:', error);
+      const conversationHistory = aiClient.getHistory(callSid);
+      const callData = {
+        callSid: session.callSid,
+        from: session.from,
+        to: session.to,
+        startTime: session.startTime,
+        endTime: getPacificTimeISO(),
+        conversationHistory: conversationHistory
+      };
+
+      const mode = config.postCallAgentMode;
+
+      if (mode === 'active') {
+        // Agent replaces existing flow, with fallback
+        try {
+          await runPostCallAgent(callData);
+          console.log(`📞 Call ended: ${callSid} - Agent summary saved`);
+        } catch (error) {
+          console.error(`❌ [${callSid}] Post-call agent failed, falling back to existing flow:`, error.message);
+          try {
+            await callSummary.saveCallSummary(callData);
+            console.log(`📞 Call ended: ${callSid} - Fallback summary saved`);
+          } catch (fallbackErr) {
+            console.error('❌ Fallback summary also failed:', fallbackErr.message);
+          }
+        }
+      } else {
+        // 'disabled' — existing flow only
+        try {
+          await callSummary.saveCallSummary(callData);
+          console.log(`📞 Call ended: ${callSid} - Summary saved`);
+        } catch (error) {
+          console.error('❌ Error saving call summary:', error);
+        }
       }
-      
+
       // Clean up
       aiClient.endSession(callSid);
       this.activeCalls.delete(callSid);

--- a/src/call-summary.js
+++ b/src/call-summary.js
@@ -100,7 +100,7 @@ ${messages.map(m => `${m.role === 'user' ? 'Caller' : 'Receptionist'}: ${m.conte
       
       // Create filename with timestamp (Pacific time)
       const timestamp = getFilenameSafeTimestamp();
-      const filename = `call-${timestamp}-${callSid.substring(0, 8)}.json`;
+      const filename = `call-${timestamp}-${callSid ? callSid.substring(0, 8) : 'unknown'}.json`;
       const filepath = path.join(this.summariesDir, filename);
       
       // Save to file
@@ -116,6 +116,45 @@ ${messages.map(m => `${m.role === 'user' ? 'Caller' : 'Receptionist'}: ${m.conte
     }
   }
   
+  /**
+   * Save a pre-built summary object directly to disk.
+   * Used by the post-call agent's save_call_summary tool.
+   * Handles both flat and accidentally-nested summary structures.
+   * @param {Object} summaryData - Pre-built summary with callSid, callerPhone, twilioNumber, startTime, endTime, duration, summary, fullTranscript
+   * @returns {string} filepath of the saved summary
+   */
+  saveSummaryDirect(summaryData) {
+    this.ensureDirectoryExists();
+
+    // Defensive: if the agent nested fields inside a 'summary' object, flatten them
+    let data = summaryData;
+    if (data.summary && typeof data.summary === 'object' && !Array.isArray(data.summary) && data.summary.callerPhone) {
+      const nested = data.summary;
+      data = { ...data, ...nested };
+      // The nested object had a 'summary' string inside it — preserve that as the actual summary text
+      if (typeof nested.summary === 'string') {
+        data.summary = nested.summary;
+      }
+    }
+
+    const { callSid, callerPhone, twilioNumber, startTime, endTime, duration, summary, fullTranscript, notificationDecision } = data;
+
+    const summaryObj = { callSid, callerPhone, twilioNumber, startTime, endTime, duration, summary, fullTranscript };
+    if (notificationDecision) {
+      summaryObj.notificationDecision = notificationDecision;
+    }
+
+    const timestamp = getFilenameSafeTimestamp();
+    const shortSid = callSid ? callSid.substring(0, 8) : 'unknown';
+    const filename = `call-${timestamp}-${shortSid}.json`;
+    const filepath = path.join(this.summariesDir, filename);
+
+    fs.writeFileSync(filepath, JSON.stringify(summaryObj, null, 2));
+    console.log(`📝 Call summary saved (direct): ${filename}`);
+
+    return filepath;
+  }
+
   /**
    * Get all call summaries
    */

--- a/src/call-summary.js
+++ b/src/call-summary.js
@@ -226,6 +226,40 @@ ${messages.map(m => `${m.role === 'user' ? 'Caller' : 'Receptionist'}: ${m.conte
       return null;
     }
   }
+
+  /**
+   * Delete a single call summary by ID
+   * @param {string} id - Call summary ID (filename without .json)
+   * @returns {boolean} true if deleted, false if not found
+   */
+  deleteSummaryById(id) {
+    const sanitizedId = path.basename(id);
+    const filename = sanitizedId.endsWith('.json') ? sanitizedId : `${sanitizedId}.json`;
+    const filepath = path.join(this.summariesDir, filename);
+
+    if (!fs.existsSync(filepath)) {
+      return false;
+    }
+
+    fs.unlinkSync(filepath);
+    return true;
+  }
+
+  /**
+   * Delete all call summary JSON files
+   * @returns {number} count of deleted files
+   */
+  deleteAllSummaries() {
+    const files = fs.readdirSync(this.summariesDir)
+      .filter(file => file.endsWith('.json'));
+
+    for (const file of files) {
+      fs.unlinkSync(path.join(this.summariesDir, file));
+    }
+
+    return files.length;
+  }
+
 }
 
 module.exports = new CallSummaryManager();

--- a/src/config.js
+++ b/src/config.js
@@ -67,7 +67,18 @@ const config = {
   admin: {
     password: process.env.ADMIN_PASSWORD || null,
     sessionSecret: process.env.SESSION_SECRET || process.env.ADMIN_PASSWORD || null
-  }
+  },
+  smtp: {
+    host: process.env.SMTP_HOST || null,
+    port: process.env.SMTP_PORT || null,
+    user: process.env.SMTP_USER || null,
+    pass: process.env.SMTP_PASS || null,
+    from: process.env.SMTP_FROM || null,
+  },
+  adminEmail: process.env.ADMIN_EMAIL || null,
+  digestEnabled: (process.env.DIGEST_ENABLED || 'false').toLowerCase() === 'true',
+  digestScheduleHour: parseInt(process.env.DIGEST_SCHEDULE_HOUR || '18', 10),
+  postCallAgentMode: (process.env.POST_CALL_AGENT_MODE || 'active').toLowerCase(),
 };
 
 // Validate on load

--- a/src/email-transport.js
+++ b/src/email-transport.js
@@ -1,53 +1,29 @@
-// Email transport module — thin wrapper around nodemailer SMTP
-// Uses lazy initialization to avoid creating TLS connections at startup,
-// which can interfere with OpenAI Realtime WebSocket audio streaming.
-const nodemailer = require('nodemailer');
+// Email transport module — uses Resend HTTP API
+// Falls back gracefully if not configured
 
-let transporter = null;
 let configured = false;
 let configChecked = false;
+let apiKey = null;
 let fromAddress = null;
 
-// Check if SMTP env vars are present (no connection created)
+// Check if email env vars are present
 function initialize() {
-  const host = process.env.SMTP_HOST;
-  const port = process.env.SMTP_PORT;
-  const user = process.env.SMTP_USER;
-  const pass = process.env.SMTP_PASS;
+  // Support both RESEND_API_KEY and SMTP_PASS (for backward compat with existing .env)
+  const key = process.env.RESEND_API_KEY || process.env.SMTP_PASS;
   const from = process.env.SMTP_FROM;
 
-  if (!host || !port || !user || !pass || !from) {
-    console.warn('⚠️ SMTP not fully configured — email notifications disabled');
+  if (!key || !from) {
+    console.warn('⚠️ Email not fully configured — email notifications disabled');
     configured = false;
     configChecked = true;
     return;
   }
 
-  // Mark as configured but don't create the transport yet
+  apiKey = key;
   fromAddress = from;
   configured = true;
   configChecked = true;
-  console.log('📧 SMTP email transport configured (lazy — connects on first send)');
-}
-
-// Create the actual nodemailer transport on demand
-function ensureTransport() {
-  if (transporter) return true;
-  if (!configured) return false;
-
-  try {
-    transporter = nodemailer.createTransport({
-      host: process.env.SMTP_HOST,
-      port: parseInt(process.env.SMTP_PORT, 10),
-      secure: true,
-      auth: { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
-    });
-    console.log('📧 SMTP transport created (first use)');
-    return true;
-  } catch (err) {
-    console.error('❌ SMTP transport creation failed:', err.message);
-    return false;
-  }
+  console.log('📧 Resend email transport configured (HTTP API)');
 }
 
 function isConfigured() {
@@ -58,15 +34,29 @@ async function sendMail({ to, subject, body }) {
   if (!configured) {
     throw new Error('Email transport is not configured');
   }
-  if (!ensureTransport()) {
-    throw new Error('Failed to create email transport');
-  }
-  return transporter.sendMail({
-    from: fromAddress,
-    to,
-    subject,
-    text: body
+
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      from: fromAddress,
+      to: Array.isArray(to) ? to : [to],
+      subject,
+      text: body
+    })
   });
+
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`Resend API error (${res.status}): ${err}`);
+  }
+
+  const data = await res.json();
+  console.log(`📧 Email sent via Resend: ${data.id}`);
+  return data;
 }
 
 module.exports = { initialize, isConfigured, sendMail };

--- a/src/email-transport.js
+++ b/src/email-transport.js
@@ -1,0 +1,72 @@
+// Email transport module — thin wrapper around nodemailer SMTP
+// Uses lazy initialization to avoid creating TLS connections at startup,
+// which can interfere with OpenAI Realtime WebSocket audio streaming.
+const nodemailer = require('nodemailer');
+
+let transporter = null;
+let configured = false;
+let configChecked = false;
+let fromAddress = null;
+
+// Check if SMTP env vars are present (no connection created)
+function initialize() {
+  const host = process.env.SMTP_HOST;
+  const port = process.env.SMTP_PORT;
+  const user = process.env.SMTP_USER;
+  const pass = process.env.SMTP_PASS;
+  const from = process.env.SMTP_FROM;
+
+  if (!host || !port || !user || !pass || !from) {
+    console.warn('⚠️ SMTP not fully configured — email notifications disabled');
+    configured = false;
+    configChecked = true;
+    return;
+  }
+
+  // Mark as configured but don't create the transport yet
+  fromAddress = from;
+  configured = true;
+  configChecked = true;
+  console.log('📧 SMTP email transport configured (lazy — connects on first send)');
+}
+
+// Create the actual nodemailer transport on demand
+function ensureTransport() {
+  if (transporter) return true;
+  if (!configured) return false;
+
+  try {
+    transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: parseInt(process.env.SMTP_PORT, 10),
+      secure: true,
+      auth: { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+    });
+    console.log('📧 SMTP transport created (first use)');
+    return true;
+  } catch (err) {
+    console.error('❌ SMTP transport creation failed:', err.message);
+    return false;
+  }
+}
+
+function isConfigured() {
+  return configured;
+}
+
+async function sendMail({ to, subject, body }) {
+  if (!configured) {
+    throw new Error('Email transport is not configured');
+  }
+  if (!ensureTransport()) {
+    throw new Error('Failed to create email transport');
+  }
+  return transporter.sendMail({
+    from: fromAddress,
+    to,
+    subject,
+    text: body
+  });
+}
+
+module.exports = { initialize, isConfigured, sendMail };

--- a/src/realtime/relay-service.js
+++ b/src/realtime/relay-service.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const callSummary = require('../call-summary');
+const config = require('../config');
 const errorBuffer = require('../error-buffer');
 const { getPacificTimeISO } = require('../time-utils');
+const { runPostCallAgent } = require('../agents/post-call-agent');
 
 /**
  * Relay Service - Bridges a Twilio Media Stream WebSocket and a Provider Adapter
@@ -176,14 +178,30 @@ class RelayService {
         content: entry.text
       }));
 
-      await callSummary.saveCallSummary({
+      const callData = {
         callSid: this.callSid,
         from: this.callerInfo.from,
         to: this.callerInfo.to,
         startTime: this.startTime,
         endTime: getPacificTimeISO(),
         conversationHistory: formattedHistory
-      });
+      };
+
+      const mode = config.postCallAgentMode;
+
+      if (mode === 'active') {
+        // Agent replaces existing flow, with fallback
+        try {
+          await runPostCallAgent(callData);
+          console.log(`📞 [${this.callSid}] Agent summary saved`);
+        } catch (agentErr) {
+          console.error(`❌ [${this.callSid}] Post-call agent failed, falling back:`, agentErr.message);
+          await callSummary.saveCallSummary(callData);
+        }
+      } else {
+        // 'disabled' — existing flow only
+        await callSummary.saveCallSummary(callData);
+      }
     } catch (err) {
       console.error(`❌ [${this.callSid}] Error saving call summary:`, err.message);
     }

--- a/src/scrape-providers.js
+++ b/src/scrape-providers.js
@@ -537,8 +537,12 @@ IMPORTANT:
 - The "fileName" field should contain only first and last name without credentials (e.g., "Miri Arie" not "Miri Arie, PhD, CGP")
 - The "insurance" field should be an array of insurance provider names
 - If no insurance information is found, return an empty array []
-- Do not use placeholder text like "Not provided" or "Not available"
+- Do not use placeholder text like "Not provided" or "Not available" in the insurance JSON array
 - Extract ALL insurance providers mentioned on the page
+- CRITICAL: In the markdown "content" field, under the ## Insurance heading:
+  - If insurance providers were found, list them
+  - If NO insurance providers were found (empty array), write: "Contact provider directly for insurance information — no insurance details available on their profile."
+  - NEVER write "[]" or leave the Insurance section empty in the markdown content
 
 Website content:
 ${text}`;
@@ -742,6 +746,16 @@ async function callLLMForProvider(providerName, text) {
     // If missing or invalid, it will be set to null and fallback logic will be used
     if (!providerData.fileName || typeof providerData.fileName !== 'string' || providerData.fileName.trim() === '') {
       providerData.fileName = null;
+    }
+
+    // Post-process: if insurance is empty, ensure the markdown content doesn't have a bare "[]"
+    if (Array.isArray(providerData.insurance) && providerData.insurance.length === 0) {
+      // Replace common patterns where the LLM writes "[]" or leaves insurance empty in markdown
+      providerData.content = providerData.content
+        .replace(/## Insurance\s*\n\s*\[\]\s*/g, '## Insurance\n\nContact provider directly for insurance information — no insurance details available on their profile.\n\n')
+        .replace(/## Insurance\s*\n\s*None\s*/gi, '## Insurance\n\nContact provider directly for insurance information — no insurance details available on their profile.\n\n')
+        .replace(/## Insurance\s*\n\s*Not provided\s*/gi, '## Insurance\n\nContact provider directly for insurance information — no insurance details available on their profile.\n\n')
+        .replace(/## Insurance\s*\n\s*Not available\s*/gi, '## Insurance\n\nContact provider directly for insurance information — no insurance details available on their profile.\n\n');
     }
 
     console.log(`✅ Successfully extracted data for ${providerName}`);

--- a/src/server.js
+++ b/src/server.js
@@ -20,6 +20,10 @@ const SessionManager = require('./realtime/session-manager');
 const RelayService = require('./realtime/relay-service');
 const { createAuthMiddleware, createLoginRouter } = require('./admin-auth');
 const { setupConsoleTimestamps } = require('./time-utils');
+const emailTransport = require('./email-transport');
+const cron = require('node-cron');
+const { runDailyDigestAgent } = require('./agents/daily-digest-agent');
+const path = require('path');
 
 // Setup console logging with Pacific time timestamps
 setupConsoleTimestamps();
@@ -918,6 +922,42 @@ wss.on('connection', (ws) => {
   });
 });
 
+// ============================================================================
+// Notification System Initialization
+// ============================================================================
+function initializeNotificationSystem() {
+  // --- SMTP transport (lazy — only validates config, no TLS connection yet) ---
+  emailTransport.initialize();
+
+  // --- Verify post-call agent prompt exists ---
+  const promptPath = path.join(__dirname, '..', 'prompts', 'post-call-agent.txt');
+  if (fs.existsSync(promptPath)) {
+    console.log('📋 Post-call agent prompt loaded');
+  } else {
+    console.warn('⚠️ Post-call agent prompt not found at prompts/post-call-agent.txt');
+  }
+
+  // --- Daily digest cron job (configurable hour, Mon-Fri) ---
+  if (config.digestEnabled && config.adminEmail) {
+    const hour = config.digestScheduleHour;
+    cron.schedule(`0 ${hour} * * 1-5`, async () => {
+      console.log('⏰ Running daily digest agent...');
+      try {
+        await runDailyDigestAgent();
+        console.log('✅ Daily digest completed');
+      } catch (err) {
+        console.error('❌ Daily digest failed:', err.message);
+        errorBuffer.add(err, 'daily-digest-cron');
+      }
+    }, { timezone: 'America/Los_Angeles' });
+    console.log(`📅 Daily digest scheduled (${hour}:00 Pacific, Mon-Fri) → ${config.adminEmail}`);
+  } else if (!config.digestEnabled) {
+    console.log('ℹ️ Daily digest disabled (DIGEST_ENABLED is not true)');
+  } else {
+    console.log('ℹ️ Daily digest not configured (no ADMIN_EMAIL set)');
+  }
+}
+
 // Start server
 const PORT = config.server.port;
 
@@ -973,6 +1013,9 @@ const PORT = config.server.port;
       if (!process.env.PUBLIC_URL) {
         console.log(`\n💡 Tip: Set PUBLIC_URL in .env to show your actual webhook URL`);
       }
+
+      // Initialize notification system (non-blocking)
+      initializeNotificationSystem();
     });
   } catch (error) {
     console.error('❌ Failed to initialize server:', error.message);

--- a/src/server.js
+++ b/src/server.js
@@ -475,6 +475,41 @@ app.get('/admin/api/calls/:id', (req, res) => {
   }
 });
 
+// Admin delete all call logs endpoint
+app.delete('/admin/api/calls', (req, res) => {
+  try {
+    const callSummaryManager = require('./call-summary');
+    const deletedCount = callSummaryManager.deleteAllSummaries();
+
+    console.log(`🗑️ All call logs deleted: ${deletedCount} files removed`);
+    res.json({ success: true, deletedCount });
+  } catch (error) {
+    console.error('❌ Error deleting all call logs:', error);
+    errorBuffer.add(error, 'admin-calls-delete-all-api');
+    res.status(500).json({ error: 'Failed to delete call logs', details: error.message });
+  }
+});
+
+// Admin delete single call log endpoint
+app.delete('/admin/api/calls/:id', (req, res) => {
+  try {
+    const id = path.basename(req.params.id);
+    const callSummaryManager = require('./call-summary');
+    const deleted = callSummaryManager.deleteSummaryById(id);
+
+    if (!deleted) {
+      return res.status(404).json({ error: 'Call log not found' });
+    }
+
+    console.log(`🗑️ Call log deleted: ${id}`);
+    res.json({ success: true, message: 'Call log deleted' });
+  } catch (error) {
+    console.error('❌ Error deleting call log:', error);
+    errorBuffer.add(error, 'admin-call-delete-api');
+    res.status(500).json({ error: 'Failed to delete call log', details: error.message });
+  }
+});
+
 // Admin availability list endpoint
 app.get('/admin/api/availability', (req, res) => {
   try {

--- a/src/test-email.js
+++ b/src/test-email.js
@@ -1,0 +1,43 @@
+// Quick SMTP test script — run with: node src/test-email.js
+// Loads .env, initializes email transport, and sends a test email
+require('dotenv').config();
+
+const emailTransport = require('./email-transport');
+
+async function main() {
+  console.log('SMTP config:');
+  console.log('  SMTP_HOST:', process.env.SMTP_HOST);
+  console.log('  SMTP_PORT:', process.env.SMTP_PORT);
+  console.log('  SMTP_USER:', process.env.SMTP_USER);
+  console.log('  SMTP_PASS:', process.env.SMTP_PASS ? '***set***' : '***MISSING***');
+  console.log('  SMTP_FROM:', process.env.SMTP_FROM);
+  console.log();
+
+  emailTransport.initialize();
+  console.log('isConfigured:', emailTransport.isConfigured());
+  console.log();
+
+  if (!emailTransport.isConfigured()) {
+    console.error('Email transport not configured — check SMTP env vars above');
+    process.exit(1);
+  }
+
+  const to = process.argv[2] || process.env.SMTP_FROM;
+  console.log(`Sending test email to: ${to}`);
+
+  try {
+    const result = await emailTransport.sendMail({
+      to,
+      subject: 'RTC Receptionist — SMTP Test',
+      body: 'If you received this, SMTP is working correctly.'
+    });
+    console.log('✅ Email sent successfully!');
+    console.log('   messageId:', result.messageId);
+    console.log('   response:', result.response);
+  } catch (err) {
+    console.error('❌ Email failed:', err.message);
+    console.error('   Full error:', err);
+  }
+}
+
+main();

--- a/tests/integration/post-call-agent.test.js
+++ b/tests/integration/post-call-agent.test.js
@@ -1,0 +1,90 @@
+// Integration test: runs real post-call agent against call bank fixtures
+// These tests hit real OpenRouter — excluded from default vitest run
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { loadAllFixtures, loadFixture } = require('../simulated_call_bank/loader.js');
+const { runPostCallAgent } = require('../../src/agents/post-call-agent.js');
+const emailTransport = require('../../src/email-transport.js');
+
+// Initialize email transport so send_email tool works (normally done by server.js at startup)
+emailTransport.initialize();
+
+const FIXTURE_ENV = process.env.FIXTURE || null;
+const TEST_TIMEOUT = 120_000; // 120s — agent calls real OpenRouter
+
+/**
+ * Extract tool call names from the agent result's steps/logs.
+ * The agent returns a Vercel AI SDK result; tool calls live in toolCalls or
+ * are captured in the agent log steps written to disk. We inspect the result
+ * object for any toolCalls array that the SDK exposes.
+ */
+function extractToolNames(result) {
+  if (!result) return [];
+  // Vercel AI SDK generateText result may have toolCalls at top level
+  if (Array.isArray(result.toolCalls)) {
+    return result.toolCalls.map(tc => tc.toolName || tc.name || 'unknown');
+  }
+  // Some SDK versions nest under steps
+  if (Array.isArray(result.steps)) {
+    return result.steps
+      .flatMap(s => s.toolCalls || [])
+      .map(tc => tc.toolName || tc.name || 'unknown');
+  }
+  return [];
+}
+
+describe('Post-Call Agent Integration', () => {
+  let fixtures;
+
+  // Load fixtures once before all tests
+  if (FIXTURE_ENV) {
+    // Single fixture mode
+    try {
+      const single = loadFixture(FIXTURE_ENV);
+      fixtures = [single];
+    } catch (err) {
+      // Will be reported inside the test block
+      fixtures = null;
+    }
+  } else {
+    fixtures = loadAllFixtures();
+  }
+
+  if (FIXTURE_ENV && fixtures === null) {
+    it(`should find fixture "${FIXTURE_ENV}"`, () => {
+      expect.fail(`Fixture not found: ${FIXTURE_ENV}`);
+    });
+  } else if (!fixtures || fixtures.length === 0) {
+    it('should have fixtures in the call bank', () => {
+      console.log('⚠️  No fixtures found in tests/simulated_call_bank/');
+      expect.fail('No fixtures found — seed some with: node tests/simulated_call_bank/seed-fixture.js <call-summary.json>');
+    });
+  } else {
+    for (const fixture of fixtures) {
+      it(
+        `should complete without throwing for fixture: ${fixture.filename}`,
+        async () => {
+          let result;
+          try {
+            result = await runPostCallAgent(fixture.data);
+          } catch (err) {
+            // Report the error clearly, then fail this fixture
+            console.error(`❌ Agent error for ${fixture.filename}:`, err.message);
+            expect.fail(`Agent threw for fixture "${fixture.filename}": ${err.message}`);
+          }
+
+          // Report which tools were called
+          const tools = extractToolNames(result);
+          if (tools.length > 0) {
+            console.log(`✅ ${fixture.filename} — tools called: ${tools.join(', ')}`);
+          } else {
+            console.log(`✅ ${fixture.filename} — completed (no tool calls detected in result)`);
+          }
+        },
+        TEST_TIMEOUT
+      );
+    }
+  }
+});

--- a/tests/integration/vitest.integration.config.js
+++ b/tests/integration/vitest.integration.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/integration/**/*.test.js'],
+    environment: 'node',
+    testTimeout: 120000,
+  }
+});

--- a/tests/simulated_call_bank/fixture-6864105d.json
+++ b/tests/simulated_call_bank/fixture-6864105d.json
@@ -1,0 +1,77 @@
+{
+  "callSid": "CAc26ac15d264ef8ddb9006b2e6864105d",
+  "from": "+15853979019",
+  "to": "",
+  "startTime": "2026-03-15T12:48:25",
+  "endTime": "2026-03-15T12:50:21",
+  "conversationHistory": [
+    {
+      "role": "assistant",
+      "content": "Hello! Thank you for calling the Relational Therapy Collective. If this is an emergency, please hang up and dial 911. I'm your AI receptionist. This call will be transcribed for quality assurance purposes. How can I help you today?"
+    },
+    {
+      "role": "user",
+      "content": "Can you tell me about therapy options for my dog?"
+    },
+    {
+      "role": "assistant",
+      "content": "I'm sorry, but we don't offer therapy services for pets. Our focus is on individual, couple, and family therapy for humans. If you need help finding resources for your dog, I'd be happy to provide some suggestions. Is there anything else I can assist you with today?"
+    },
+    {
+      "role": "assistant",
+      "content": "If you have any questions"
+    },
+    {
+      "role": "user",
+      "content": "Okay."
+    },
+    {
+      "role": "user",
+      "content": "So, for my son."
+    },
+    {
+      "role": "assistant",
+      "content": "I'd be glad to help with finding support for your son. May I ask a few questions to better assist you? First, could you tell me his age? Also, what are the main concerns or reasons for reaching out?"
+    },
+    {
+      "role": "user",
+      "content": "Sure"
+    },
+    {
+      "role": "assistant",
+      "content": "Great! Could you please share his age and the main concerns or reasons you're seeking therapy for him? This will help me find the best options for his needs."
+    },
+    {
+      "role": "user",
+      "content": "He's three years old and he's not talking yet."
+    },
+    {
+      "role": "assistant",
+      "content": "Thank you for sharing that. Since your son is 3 years old and experiencing speech delays, we have providers who specialize in working with young children with similar challenges. I recommend considering Miri Arie, who has specialized training in working with young children, or Claire de Leon, who specializes in child mental health and selective mutism. Would you prefer in-person or telehealth sessions, and do you have any insurance preferences?"
+    },
+    {
+      "role": "user",
+      "content": "Does any of them accept insurance?"
+    },
+    {
+      "role": "assistant",
+      "content": "Miri Arie and Claire de Leon both work as out-of-network providers, which means they accept payment at the time of each session. They can provide a superbill for you to submit to your insurance company for possible reimbursement. Please check with your insurance provider to confirm your mental health coverage and reimbursement options. Would you like their contact information?"
+    },
+    {
+      "role": "user",
+      "content": "Are you sure Claire de Leon doesn't accept insurance?"
+    },
+    {
+      "role": "assistant",
+      "content": "You are correct; Claire de Leon does accept some insurance providers. She accepts Premera, Aetna, United Health Care (including Apple Health), and Lyra. If your insurance provider is not listed, she can work as an out-of-network provider. Would you like her contact information for further details?"
+    },
+    {
+      "role": "user",
+      "content": "And what about Dr. Rowley?"
+    },
+    {
+      "role": "assistant",
+      "content": "Dr. Miri Arie works as an out-of-network provider. This means she doesn't directly bill insurance but can provide a superbill for you to submit to your insurance company for possible reimbursement. Would you like her contact information for more details on her services?"
+    }
+  ]
+}

--- a/tests/simulated_call_bank/loader.js
+++ b/tests/simulated_call_bank/loader.js
@@ -1,0 +1,81 @@
+// Fixture loader and validator for the simulated call bank
+// Reads, validates, and returns call fixture JSON files for post-call agent testing
+
+const fs = require('fs');
+const path = require('path');
+
+const CALL_BANK_DIR = __dirname;
+
+const REQUIRED_FIELDS = ['callSid', 'from', 'to', 'startTime', 'endTime', 'conversationHistory'];
+
+/**
+ * Validates a call fixture has all required fields and correct structure.
+ * Throws an error identifying the filename and missing/invalid field.
+ * @param {object} data - The fixture data to validate
+ * @param {string} filename - The fixture filename (used in error messages)
+ */
+function validateFixture(data, filename) {
+  for (const field of REQUIRED_FIELDS) {
+    if (data[field] === undefined || data[field] === null) {
+      throw new Error(`Fixture "${filename}" is missing required field: ${field}`);
+    }
+  }
+
+  if (!Array.isArray(data.conversationHistory)) {
+    throw new Error(`Fixture "${filename}" has invalid field: conversationHistory must be an array`);
+  }
+
+  for (let i = 0; i < data.conversationHistory.length; i++) {
+    const entry = data.conversationHistory[i];
+    if (!entry || typeof entry.role !== 'string') {
+      throw new Error(`Fixture "${filename}" has invalid conversationHistory[${i}]: missing role`);
+    }
+    if (!entry || typeof entry.content !== 'string') {
+      throw new Error(`Fixture "${filename}" has invalid conversationHistory[${i}]: missing content`);
+    }
+  }
+}
+
+/**
+ * Loads all .json fixture files from the call bank directory.
+ * Returns an empty array if the directory is empty or missing.
+ * @returns {Array<{filename: string, data: object}>}
+ */
+function loadAllFixtures() {
+  if (!fs.existsSync(CALL_BANK_DIR)) {
+    return [];
+  }
+
+  const files = fs.readdirSync(CALL_BANK_DIR).filter(f => f.endsWith('.json'));
+  if (files.length === 0) {
+    return [];
+  }
+
+  return files.map(filename => {
+    const filepath = path.join(CALL_BANK_DIR, filename);
+    const raw = fs.readFileSync(filepath, 'utf-8');
+    const data = JSON.parse(raw);
+    validateFixture(data, filename);
+    return { filename, data };
+  });
+}
+
+/**
+ * Loads a single fixture by filename.
+ * @param {string} filename - The fixture filename to load
+ * @returns {{filename: string, data: object}}
+ * @throws {Error} If the file doesn't exist or fails validation
+ */
+function loadFixture(filename) {
+  const filepath = path.join(CALL_BANK_DIR, filename);
+  if (!fs.existsSync(filepath)) {
+    throw new Error(`Fixture file not found: ${filename}`);
+  }
+
+  const raw = fs.readFileSync(filepath, 'utf-8');
+  const data = JSON.parse(raw);
+  validateFixture(data, filename);
+  return { filename, data };
+}
+
+module.exports = { loadAllFixtures, loadFixture, validateFixture };

--- a/tests/simulated_call_bank/seed-fixture.js
+++ b/tests/simulated_call_bank/seed-fixture.js
@@ -1,0 +1,116 @@
+// Seed utility: converts a call summary JSON into a call fixture for the simulated call bank
+// Usage: node tests/simulated_call_bank/seed-fixture.js call-summaries/call-2026-03-15-12-50-31-CAc26ac1.json
+// Also exports convertSummaryToFixture for use in property tests
+
+const fs = require('fs');
+const path = require('path');
+
+const CALL_BANK_DIR = __dirname;
+
+/**
+ * Maps a transcript speaker name to a conversation role.
+ * "Caller" → "user", "AI Receptionist" → "assistant", unknown → "user"
+ */
+function mapSpeakerToRole(speaker) {
+  if (speaker === 'AI Receptionist') return 'assistant';
+  return 'user';
+}
+
+/**
+ * Derives an endTime ISO string from a startTime and a duration string like "116 seconds".
+ * Returns empty string if parsing fails.
+ */
+function deriveEndTime(startTime, durationStr) {
+  try {
+    const match = durationStr.match(/(\d+)/);
+    if (!match) return '';
+    const seconds = parseInt(match[1], 10);
+    // Parse as local (no Z suffix) to match the startTime format from getPacificTimeISO()
+    const start = new Date(startTime + 'Z'); // treat input as UTC for arithmetic
+    if (isNaN(start.getTime())) return '';
+    const end = new Date(start.getTime() + seconds * 1000);
+    // Return in same format as startTime (YYYY-MM-DDTHH:MM:SS, no Z)
+    return end.toISOString().replace('Z', '').replace(/\.\d{3}$/, '');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Converts a call summary (flat or nested) into the fixture format
+ * expected by runPostCallAgent.
+ *
+ * @param {object} raw - The raw call summary JSON
+ * @returns {object} A fixture with callSid, from, to, startTime, endTime, conversationHistory
+ */
+function convertSummaryToFixture(raw) {
+  // Detect nested vs flat: nested has summary as an object with callerPhone
+  const isNested = raw.summary && typeof raw.summary === 'object' && raw.summary.callerPhone;
+
+  let callSid, callerPhone, twilioNumber, startTime, endTime, fullTranscript;
+
+  if (isNested) {
+    callSid = raw.callSid;
+    callerPhone = raw.summary.callerPhone;
+    twilioNumber = raw.summary.twilioNumber || '';
+    startTime = raw.summary.callDate || raw.summary.startTime || '';
+    endTime = raw.summary.endTime || '';
+    fullTranscript = raw.summary.fullTranscript || [];
+    // Derive endTime from startTime + duration when missing
+    if (!endTime && startTime && raw.summary.duration) {
+      endTime = deriveEndTime(startTime, raw.summary.duration);
+    }
+  } else {
+    callSid = raw.callSid;
+    callerPhone = raw.callerPhone || '';
+    twilioNumber = raw.twilioNumber || '';
+    startTime = raw.startTime || '';
+    endTime = raw.endTime || '';
+    fullTranscript = raw.fullTranscript || [];
+    if (!endTime && startTime && raw.duration) {
+      endTime = deriveEndTime(startTime, raw.duration);
+    }
+  }
+
+  const conversationHistory = fullTranscript.map(entry => ({
+    role: mapSpeakerToRole(entry.speaker),
+    content: entry.message,
+  }));
+
+  return {
+    callSid,
+    from: callerPhone,
+    to: twilioNumber,
+    startTime,
+    endTime,
+    conversationHistory,
+  };
+}
+
+// CLI entry point
+if (require.main === module) {
+  const inputPath = process.argv[2];
+  if (!inputPath) {
+    console.error('Usage: node tests/simulated_call_bank/seed-fixture.js <call-summary-json-path>');
+    process.exit(1);
+  }
+
+  const resolved = path.resolve(inputPath);
+  if (!fs.existsSync(resolved)) {
+    console.error(`File not found: ${resolved}`);
+    process.exit(1);
+  }
+
+  const raw = JSON.parse(fs.readFileSync(resolved, 'utf-8'));
+  const fixture = convertSummaryToFixture(raw);
+
+  // Derive output filename from callSid short form (last 8 hex chars)
+  const sidShort = fixture.callSid ? fixture.callSid.slice(-8) : 'unknown';
+  const outName = `fixture-${sidShort}.json`;
+  const outPath = path.join(CALL_BANK_DIR, outName);
+
+  fs.writeFileSync(outPath, JSON.stringify(fixture, null, 2) + '\n', 'utf-8');
+  console.log(`Fixture written to ${outPath}`);
+}
+
+module.exports = { convertSummaryToFixture, mapSpeakerToRole };

--- a/tests/unit/admin-auth-middleware.test.js
+++ b/tests/unit/admin-auth-middleware.test.js
@@ -44,10 +44,11 @@ describe('createAuthMiddleware', () => {
   describe('when adminPassword is set', () => {
     const adminPassword = 'test-password-123';
     
-    it('should skip authentication for /admin/login', () => {
+    it('should skip authentication for /login (mount-relative path)', () => {
       const middleware = createAuthMiddleware(adminPassword);
       
-      const req = { path: '/admin/login', cookies: {} };
+      // Note: req.path is relative to the mount point (/admin)
+      const req = { path: '/login', cookies: {} };
       const res = {};
       let nextCalled = false;
       const next = () => { nextCalled = true; };
@@ -109,8 +110,9 @@ describe('createAuthMiddleware', () => {
     it('should return 401 JSON for API requests without valid session', () => {
       const middleware = createAuthMiddleware(adminPassword);
       
+      // Note: req.path is relative to the mount point (/admin)
       const req = { 
-        path: '/admin/api/calls',
+        path: '/api/calls',
         cookies: {}
       };
       let statusCode = null;

--- a/tests/unit/insurance-statistics.test.js
+++ b/tests/unit/insurance-statistics.test.js
@@ -8,13 +8,15 @@ describe('Insurance Statistics in Scraping Report', () => {
   const testReportPath = path.join(reportsDir, 'scraping-report-2024-01-01T00-00-00-000Z.md');
 
   beforeEach(() => {
+    // Ensure reports directory exists for tests that write files
+    if (!fs.existsSync(reportsDir)) {
+      fs.mkdirSync(reportsDir, { recursive: true });
+    }
     // Clean up ALL existing reports to ensure clean test environment
-    if (fs.existsSync(reportsDir)) {
-      const files = fs.readdirSync(reportsDir);
-      for (const file of files) {
-        if (file.startsWith('scraping-report-') && file.endsWith('.md')) {
-          fs.unlinkSync(path.join(reportsDir, file));
-        }
+    const files = fs.readdirSync(reportsDir);
+    for (const file of files) {
+      if (file.startsWith('scraping-report-') && file.endsWith('.md')) {
+        fs.unlinkSync(path.join(reportsDir, file));
       }
     }
   });

--- a/tests/unit/prompts.test.js
+++ b/tests/unit/prompts.test.js
@@ -8,15 +8,18 @@ const __dirname = path.dirname(__filename);
 
 describe('Prompts Module', () => {
   let prompts;
-  const testPromptsDir = path.join(__dirname, '..', '..', 'prompts');
   const testFilename = 'greeting.txt';
-  const testFilePath = path.join(testPromptsDir, testFilename);
-  let originalContent;
+  // savePrompt() now writes to data/prompts/ (override dir), not prompts/ (repo defaults)
+  const dataPromptsDir = path.join(__dirname, '..', '..', 'data', 'prompts');
+  const overrideFilePath = path.join(dataPromptsDir, testFilename);
+  let originalOverrideContent;
+  let overrideExisted;
 
   beforeEach(async () => {
-    // Store original content
-    if (fs.existsSync(testFilePath)) {
-      originalContent = fs.readFileSync(testFilePath, 'utf-8');
+    // Store original override content if it exists
+    overrideExisted = fs.existsSync(overrideFilePath);
+    if (overrideExisted) {
+      originalOverrideContent = fs.readFileSync(overrideFilePath, 'utf-8');
     }
     
     // Dynamic import to get fresh instance
@@ -25,9 +28,11 @@ describe('Prompts Module', () => {
   });
 
   afterEach(() => {
-    // Restore original content
-    if (originalContent !== undefined) {
-      fs.writeFileSync(testFilePath, originalContent, 'utf-8');
+    // Restore or remove the override file
+    if (overrideExisted) {
+      fs.writeFileSync(overrideFilePath, originalOverrideContent, 'utf-8');
+    } else if (fs.existsSync(overrideFilePath)) {
+      fs.unlinkSync(overrideFilePath);
     }
   });
 
@@ -67,7 +72,8 @@ describe('Prompts Module', () => {
       
       prompts.savePrompt(testFilename, newContent);
       
-      const savedContent = fs.readFileSync(testFilePath, 'utf-8');
+      // savePrompt writes to data/prompts/ (override dir)
+      const savedContent = fs.readFileSync(overrideFilePath, 'utf-8');
       expect(savedContent).toBe(newContent);
       
       // Verify it's in the cache

--- a/tests/unit/scrape-providers-reporting.test.js
+++ b/tests/unit/scrape-providers-reporting.test.js
@@ -171,10 +171,9 @@ describe('Report Writing', () => {
     const filepath = writeReport(mockReport);
     
     if (filepath) {
-      // Verify filename format
+      // Verify filename format (Pacific time: scraping-report-YYYY-MM-DD-HH-MM-SS.md)
       const filename = path.basename(filepath);
-      expect(filename).toMatch(/^scraping-report-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}/);
-      expect(filename).toContain('.md');
+      expect(filename).toMatch(/^scraping-report-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.md$/);
       
       // Clean up test file
       if (fs.existsSync(filepath)) {

--- a/tests/unit/write-report.test.js
+++ b/tests/unit/write-report.test.js
@@ -8,18 +8,33 @@ describe('writeReport', () => {
   const reportsDir = path.join(process.cwd(), 'reports');
   let createdFiles = [];
 
+  // Ensure reports directory exists before each test
+  beforeEach(() => {
+    if (!fs.existsSync(reportsDir)) {
+      fs.mkdirSync(reportsDir, { recursive: true });
+    }
+  });
+
   // Clean up created files after each test
   afterEach(() => {
     createdFiles.forEach(filepath => {
-      if (fs.existsSync(filepath)) {
-        fs.unlinkSync(filepath);
+      try {
+        if (fs.existsSync(filepath)) {
+          fs.unlinkSync(filepath);
+        }
+      } catch (e) {
+        // Ignore cleanup errors
       }
     });
     createdFiles = [];
 
     // Remove reports directory if empty
-    if (fs.existsSync(reportsDir) && fs.readdirSync(reportsDir).length === 0) {
-      fs.rmdirSync(reportsDir);
+    try {
+      if (fs.existsSync(reportsDir) && fs.readdirSync(reportsDir).length === 0) {
+        fs.rmdirSync(reportsDir);
+      }
+    } catch (e) {
+      // Ignore cleanup errors — directory may not be empty due to concurrent tests
     }
   });
 
@@ -48,7 +63,8 @@ describe('writeReport', () => {
     
     if (filepath) {
       const filename = path.basename(filepath);
-      expect(filename).toMatch(/^scraping-report-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z\.md$/);
+      // Filename uses Pacific time: scraping-report-YYYY-MM-DD-HH-MM-SS.md
+      expect(filename).toMatch(/^scraping-report-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.md$/);
       createdFiles.push(filepath);
     }
   });
@@ -90,23 +106,25 @@ describe('writeReport', () => {
 
     const filepath1 = writeReport(reportContent1);
     
-    // Small delay to ensure different timestamps
-    const start = Date.now();
-    while (Date.now() - start < 10) {
-      // Wait a bit
-    }
-    
-    const filepath2 = writeReport(reportContent2);
-
+    // Verify first file exists immediately after write
     expect(filepath1).toBeTruthy();
-    expect(filepath2).toBeTruthy();
-    expect(filepath1).not.toBe(filepath2);
-
     if (filepath1) {
       expect(fs.existsSync(filepath1)).toBe(true);
       createdFiles.push(filepath1);
     }
+
+    // Wait at least 1 second to ensure different Pacific-time timestamps (second granularity)
+    const start = Date.now();
+    while (Date.now() - start < 1100) {
+      // Wait for timestamp to change
+    }
     
+    const filepath2 = writeReport(reportContent2);
+
+    // Verify second file exists and paths differ
+    expect(filepath2).toBeTruthy();
+    expect(filepath1).not.toBe(filepath2);
+
     if (filepath2) {
       expect(fs.existsSync(filepath2)).toBe(true);
       createdFiles.push(filepath2);

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,6 +5,15 @@ export default defineConfig({
     // Test files pattern
     include: ['tests/**/*.test.js', 'tests/**/*.property.test.js'],
     
+    // Exclude slow integration tests that hit real external APIs
+    // and long-running WebSocket tests (run manually with: npx vitest run tests/property/websocket-*)
+    exclude: [
+      'tests/unit/mainMultiPage.test.js',
+      'tests/property/websocket-timeout.property.test.js',
+      'tests/property/websocket-preservation.property.test.js',
+      'tests/integration/post-call-agent.test.js',
+    ],
+    
     // Environment
     environment: 'node',
     


### PR DESCRIPTION
## Summary

- Brings in all changes from `feature/post-call-agents` (post-call agent infrastructure, new agents, email transport, tests)
- Adds `DEPLOYMENTS.md` from `chargewizards` (ChargeWizards deployment log)
- Rewrites `prompts/post-call-agent.txt` to replicate the old hardcoded post-call behavior — summary only, no email notifications — so this is not a breaking change from `main`

## What the post-call agent does by default (matching old behavior)

Generates a 3-4 sentence summary (what caller wanted, info provided, clinicians mentioned, next steps) and saves it to disk. Email notifications are off by default but can be enabled later by overriding the prompt via `data/prompts/post-call-agent.txt`.

## Test plan

- [ ] Run locally with a real call and confirm a call summary JSON is saved to `call-summaries/`
- [ ] Confirm no email is sent during the call
- [ ] Check `data/agent_logs/` for the agent debug log
- [ ] Deploy to one prod server and verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)