### PR TITLE
feat: autoresearch — automated prompt optimization tool

### DIFF
--- a/tools/autoresearch/.env.example
+++ b/tools/autoresearch/.env.example
@@ -1,0 +1,13 @@
+# Server where receptionist is deployed
+REMOTE_HOST=root@your-server-ip
+REMOTE_PASS=your-ssh-password
+REMOTE_PROMPT=/opt/receptionist/prompts/system-prompt.txt
+
+# Receptionist webchat API endpoint
+RECEPTIONIST_URL=https://your-receptionist-url.com
+
+# Systemd service name (for restart after prompt changes)
+SERVICE_NAME=receptionist
+
+# Scorer model (via OpenRouter — API key fetched from server's .env)
+SCORER_MODEL=openai/gpt-4o

--- a/tools/autoresearch/.gitignore
+++ b/tools/autoresearch/.gitignore
@@ -1,0 +1,6 @@
+.env
+results/
+prompt-backup.txt
+prompt-current.txt
+changelog.md
+__pycache__/

--- a/tools/autoresearch/README.md
+++ b/tools/autoresearch/README.md
@@ -1,0 +1,167 @@
+# Autoresearch — Automated Prompt Optimization
+
+Inspired by [Karpathy's autoresearch method](https://github.com/karpathy/autoresearch). Automatically tests your receptionist's system prompt against simulated conversations, scores it, suggests improvements, and deploys them — only if they actually improve the score.
+
+## How It Works
+
+```
+┌─────────────┐     ┌──────────────┐     ┌─────────────┐
+│  Scenarios   │────▶│  Simulate    │────▶│   Score     │
+│  (your test  │     │  conversations│     │  against    │
+│   cases)     │     │  via webchat  │     │  criteria   │
+└─────────────┘     └──────────────┘     └──────┬──────┘
+                                                │
+                    ┌──────────────┐     ┌──────▼──────┐
+                    │  Deploy if   │◀────│  Generate   │
+                    │  score ↑     │     │  improvement│
+                    └──────────────┘     └─────────────┘
+```
+
+1. **Define scenarios** — Simulated customer conversations (new patient, price inquiry, emergency, spam, etc.)
+2. **Define criteria** — What "good" looks like (short greeting, captures contact info, handles trolls, etc.)
+3. **Run baseline** — Score the current prompt against all scenarios
+4. **Improve** — AI analyzes failures, suggests ONE surgical prompt edit, tests it
+5. **Keep or revert** — If score improves, the change sticks. If not, it rolls back automatically.
+
+## Quick Start
+
+### 1. Copy and configure
+
+```bash
+cd tools/autoresearch
+cp .env.example .env
+# Edit .env with your server details
+```
+
+### 2. Create your scenarios
+
+Edit `scenarios.json` — each scenario is a simulated customer conversation:
+
+```json
+[
+  {
+    "id": "new-patient",
+    "description": "New patient calling to schedule an appointment",
+    "messages": [
+      "Hi, I'd like to schedule an appointment",
+      "I'm a new patient",
+      "My name is Sarah, I'm in downtown",
+      "555-123-4567"
+    ]
+  }
+]
+```
+
+### 3. Define your criteria
+
+Edit `criteria.json` — what the receptionist should do in each scenario:
+
+```json
+{
+  "criteria": [
+    {
+      "id": "greeting",
+      "question": "Is the greeting short and natural (under 2 sentences)?",
+      "applies_to": ["new-patient", "returning-patient", "price-inquiry"]
+    },
+    {
+      "id": "contact-capture",
+      "question": "Did the receptionist collect at least name and phone number?",
+      "applies_to": ["new-patient", "price-inquiry"]
+    }
+  ]
+}
+```
+
+### 4. Run it
+
+```bash
+# Score current prompt
+python3 run.py baseline
+
+# Run one improvement round (suggest + test + deploy/revert)
+python3 run.py improve
+
+# Run N improvement rounds
+python3 run.py loop 5
+
+# Show history
+python3 run.py report
+```
+
+## Configuration
+
+### `.env` file
+
+```bash
+# Server where receptionist is deployed
+REMOTE_HOST=root@your-server-ip
+REMOTE_PASS=your-ssh-password
+REMOTE_PROMPT=/opt/receptionist/prompts/system-prompt.txt
+
+# Receptionist webchat API endpoint
+RECEPTIONIST_URL=https://your-receptionist-url.com
+
+# Scorer model (uses OpenRouter — key fetched from server's .env)
+# The scorer evaluates David's responses against your criteria
+```
+
+### Scenarios
+
+Each scenario simulates a customer interaction. The `messages` array contains what the customer says — the receptionist responds via the webchat API.
+
+**Tips for writing good scenarios:**
+- Cover your most common call types (70% of your volume)
+- Include edge cases (spam, out-of-area, angry customer)
+- Include at least one multi-language scenario if applicable
+- Keep messages realistic — short, sometimes misspelled, sometimes vague
+
+### Criteria
+
+Each criterion is a yes/no question that a scoring model evaluates. The `applies_to` array maps criteria to scenarios.
+
+**Tips for writing good criteria:**
+- Be specific and measurable ("Did the receptionist ask for a phone number?" not "Was the receptionist helpful?")
+- Test one thing per criterion
+- Include both positive criteria (what to do) and negative criteria (what NOT to do)
+
+## Automation
+
+Run autoresearch on a schedule (e.g., weekly) to continuously improve your receptionist:
+
+```bash
+# Example cron: every Monday at 4am
+0 4 * * 1 cd /path/to/tools/autoresearch && python3 run.py loop 3 >> /var/log/autoresearch.log 2>&1
+```
+
+## How Scoring Works
+
+1. Each scenario is played through the webchat API
+2. The full conversation is sent to GPT-4o (via OpenRouter) with the criteria
+3. GPT-4o evaluates each applicable criterion as PASS or FAIL
+4. Score = total passes / total checks across all scenarios
+
+## How Improvement Works
+
+1. All failures are collected and sent to GPT-4o
+2. GPT-4o suggests ONE surgical edit to the system prompt
+3. The edit is applied and the full baseline is re-run
+4. If score improves → change is kept, logged to `changelog.md`
+5. If score doesn't improve → change is reverted, also logged
+
+**Safety:** The original prompt is always backed up to `prompt-backup.txt` before any changes. You can always restore it.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `run.py` | Main runner — baseline, improve, loop, report |
+| `scorer.py` | Calls OpenRouter to evaluate conversations |
+| `scenarios.json` | Your test scenarios (customize these!) |
+| `criteria.json` | Your scoring criteria (customize these!) |
+| `.env` | Server credentials (never committed) |
+| `.env.example` | Template for `.env` |
+| `changelog.md` | Auto-generated log of all prompt changes |
+| `results/` | JSON results from each run |
+| `prompt-backup.txt` | Backup of original prompt |
+| `prompt-current.txt` | Current prompt (synced from server) |

--- a/tools/autoresearch/criteria.json
+++ b/tools/autoresearch/criteria.json
@@ -1,0 +1,59 @@
+{
+  "criteria": [
+    {
+      "id": "greeting",
+      "question": "Is the greeting short and natural (under 2 sentences, no listing of services)?",
+      "applies_to": ["new-client-basic", "price-inquiry", "existing-client", "spanish-speaker"]
+    },
+    {
+      "id": "qualification",
+      "question": "Did the receptionist gather at least 2 of: name, location, phone, email, service needed?",
+      "applies_to": ["new-client-basic", "price-inquiry", "spanish-speaker"]
+    },
+    {
+      "id": "contact-capture",
+      "question": "Did the receptionist collect a phone number or email for follow-up?",
+      "applies_to": ["new-client-basic", "price-inquiry", "spanish-speaker"]
+    },
+    {
+      "id": "concise-responses",
+      "question": "Were all of the receptionist's responses 3 sentences or fewer?",
+      "applies_to": ["new-client-basic", "price-inquiry", "existing-client", "out-of-area", "spam-vendor", "spanish-speaker"]
+    },
+    {
+      "id": "no-filler-praise",
+      "question": "Did the receptionist avoid filler praise words like 'Great!', 'Perfect!', 'Excellent!', 'Awesome!'?",
+      "applies_to": ["new-client-basic", "price-inquiry", "spanish-speaker"]
+    },
+    {
+      "id": "clean-ending",
+      "question": "Did the conversation end with a clear next step (e.g., 'someone will be in touch', 'we'll call you back')?",
+      "applies_to": ["new-client-basic", "price-inquiry", "existing-client", "spanish-speaker"]
+    },
+    {
+      "id": "no-premature-price",
+      "question": "Did the receptionist ask qualifying questions BEFORE sharing any price information?",
+      "applies_to": ["price-inquiry"]
+    },
+    {
+      "id": "out-of-area-polite",
+      "question": "Did the receptionist politely decline and not waste the caller's time with unnecessary questions?",
+      "applies_to": ["out-of-area"]
+    },
+    {
+      "id": "vendor-handling",
+      "question": "Did the receptionist identify this as a vendor/marketing call and handle it efficiently (take a message or decline)?",
+      "applies_to": ["spam-vendor"]
+    },
+    {
+      "id": "off-topic-2strike",
+      "question": "Did the receptionist redirect once, then disengage cleanly on the second off-topic attempt (not repeat the same script)?",
+      "applies_to": ["off-topic-troll"]
+    },
+    {
+      "id": "language-match",
+      "question": "Did the receptionist respond in the same language as the caller?",
+      "applies_to": ["spanish-speaker"]
+    }
+  ]
+}

--- a/tools/autoresearch/run.py
+++ b/tools/autoresearch/run.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""
+Autoresearch — Automated Prompt Optimization for AI Receptionists
+Inspired by Karpathy's autoresearch method.
+
+Runs your system prompt against test scenarios, scores against criteria,
+suggests improvements, and iterates.
+
+Usage:
+  python3 run.py baseline          # Score current prompt
+  python3 run.py improve           # Run one improvement round
+  python3 run.py loop [N]          # Run N improvement rounds (default 5)
+  python3 run.py report            # Show history of all rounds
+"""
+
+import json
+import os
+import sys
+import subprocess
+import datetime
+import shutil
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+SCENARIOS_FILE = SCRIPT_DIR / "scenarios.json"
+CRITERIA_FILE = SCRIPT_DIR / "criteria.json"
+RESULTS_DIR = SCRIPT_DIR / "results"
+CHANGELOG_FILE = SCRIPT_DIR / "changelog.md"
+
+
+def _load_env():
+    """Load credentials from .env file."""
+    env = {}
+    env_file = SCRIPT_DIR / ".env"
+    if not env_file.exists():
+        print("❌ Missing .env file! Copy .env.example and fill in credentials.")
+        sys.exit(1)
+    for line in env_file.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            k, v = line.split("=", 1)
+            env[k.strip()] = v.strip()
+    return env
+
+
+_ENV = _load_env()
+REMOTE_HOST = _ENV["REMOTE_HOST"]
+REMOTE_PASS = _ENV["REMOTE_PASS"]
+REMOTE_PROMPT = _ENV["REMOTE_PROMPT"]
+RECEPTIONIST_URL = _ENV["RECEPTIONIST_URL"]
+SERVICE_NAME = _ENV.get("SERVICE_NAME", "receptionist")
+
+LOCAL_PROMPT_BACKUP = SCRIPT_DIR / "prompt-backup.txt"
+LOCAL_PROMPT_CURRENT = SCRIPT_DIR / "prompt-current.txt"
+
+
+def ssh_cmd(cmd):
+    """Run a command on the remote server."""
+    full = f"sshpass -p '{REMOTE_PASS}' ssh -o StrictHostKeyChecking=no {REMOTE_HOST} '{cmd}'"
+    result = subprocess.run(full, shell=True, capture_output=True, text=True, timeout=30)
+    return result.stdout.strip()
+
+
+def fetch_prompt():
+    """Download current system prompt from server."""
+    prompt = ssh_cmd(f"cat {REMOTE_PROMPT}")
+    LOCAL_PROMPT_CURRENT.write_text(prompt)
+    return prompt
+
+
+def push_prompt(prompt_text):
+    """Upload new system prompt to server and restart service."""
+    LOCAL_PROMPT_CURRENT.write_text(prompt_text)
+    tmp = "/tmp/autoresearch-prompt-upload.txt"
+    Path(tmp).write_text(prompt_text)
+    subprocess.run(
+        f"sshpass -p '{REMOTE_PASS}' scp -o StrictHostKeyChecking=no {tmp} {REMOTE_HOST}:{REMOTE_PROMPT}",
+        shell=True, capture_output=True, timeout=30
+    )
+    ssh_cmd(f"systemctl restart {SERVICE_NAME}")
+    import time
+    time.sleep(3)
+
+
+def simulate_conversation(scenario, system_prompt):
+    """Simulate a conversation using the receptionist's webchat API."""
+    import urllib.request
+    import ssl
+    import uuid
+
+    ctx = ssl.create_default_context()
+    messages = []
+    david_responses = []
+    session_id = f"autoresearch-{uuid.uuid4().hex[:8]}"
+
+    for user_msg in scenario["messages"]:
+        messages.append({"role": "user", "content": user_msg})
+
+        payload = json.dumps({
+            "sessionId": session_id,
+            "messages": messages
+        }).encode()
+
+        req = urllib.request.Request(
+            f"{RECEPTIONIST_URL}/api/webchat",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST"
+        )
+
+        try:
+            with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+                data = json.loads(resp.read())
+                david_reply = data.get("response", data.get("reply", ""))
+                if isinstance(david_reply, dict):
+                    david_reply = david_reply.get("response", str(david_reply))
+                david_responses.append(david_reply)
+                messages.append({"role": "assistant", "content": david_reply})
+        except Exception as e:
+            david_responses.append(f"[ERROR: {e}]")
+            messages.append({"role": "assistant", "content": "[ERROR]"})
+
+    return {
+        "scenario_id": scenario["id"],
+        "description": scenario.get("description", ""),
+        "conversation": messages,
+        "david_responses": david_responses
+    }
+
+
+def score_conversation(conv_result, criteria, system_prompt):
+    """Use an LLM to score a conversation against criteria."""
+    applicable = [c for c in criteria if conv_result["scenario_id"] in c["applies_to"]]
+    if not applicable:
+        return {"scenario_id": conv_result["scenario_id"], "checks": [], "score": 1.0, "passed": 0, "total": 0}
+
+    conv_text = ""
+    for msg in conv_result["conversation"]:
+        role = "Customer" if msg["role"] == "user" else "Receptionist"
+        conv_text += f"{role}: {msg['content']}\n"
+
+    checks_text = "\n".join([f"- {c['id']}: {c['question']}" for c in applicable])
+
+    scoring_prompt = f"""Score this conversation. For each criterion, answer YES or NO only.
+
+CONVERSATION:
+{conv_text}
+
+CRITERIA (answer YES if met, NO if not):
+{checks_text}
+
+Respond in JSON format exactly like this:
+{{"results": [{{"id": "criterion_id", "pass": true/false, "reason": "brief reason"}}]}}
+
+Be strict. If borderline, score NO."""
+
+    result = subprocess.run(
+        ["python3", str(SCRIPT_DIR / "scorer.py"), scoring_prompt],
+        capture_output=True, text=True, timeout=120
+    )
+
+    try:
+        scores = json.loads(result.stdout)
+        passed = sum(1 for r in scores["results"] if r["pass"])
+        total = len(scores["results"])
+        return {
+            "scenario_id": conv_result["scenario_id"],
+            "checks": scores["results"],
+            "score": passed / total if total > 0 else 1.0,
+            "passed": passed,
+            "total": total
+        }
+    except (json.JSONDecodeError, KeyError):
+        print(f"  ⚠️  Scoring failed for {conv_result['scenario_id']}: {result.stdout[:200]}")
+        return {
+            "scenario_id": conv_result["scenario_id"],
+            "checks": [],
+            "score": 0.0,
+            "passed": 0,
+            "total": 0,
+            "error": result.stdout[:500]
+        }
+
+
+def run_baseline():
+    """Score the current prompt against all scenarios."""
+    print("📥 Fetching current prompt from server...")
+    prompt = fetch_prompt()
+
+    if not LOCAL_PROMPT_BACKUP.exists():
+        LOCAL_PROMPT_BACKUP.write_text(prompt)
+        print("💾 Saved backup of original prompt")
+
+    scenarios = json.loads(SCENARIOS_FILE.read_text())
+    criteria = json.loads(CRITERIA_FILE.read_text())["criteria"]
+
+    print(f"\n🧪 Running {len(scenarios)} scenarios...")
+    all_scores = []
+
+    for scenario in scenarios:
+        print(f"  ▸ {scenario['id']}...", end=" ", flush=True)
+        conv = simulate_conversation(scenario, prompt)
+        score = score_conversation(conv, criteria, prompt)
+        all_scores.append(score)
+        status = "✅" if score["score"] >= 0.8 else "⚠️" if score["score"] >= 0.5 else "❌"
+        print(f"{status} {score.get('passed', '?')}/{score.get('total', '?')} ({score['score']:.0%})")
+
+    total_passed = sum(s.get("passed", 0) for s in all_scores)
+    total_checks = sum(s.get("total", 0) for s in all_scores)
+    overall = total_passed / total_checks if total_checks > 0 else 0
+
+    print(f"\n{'='*50}")
+    print(f"📊 BASELINE SCORE: {total_passed}/{total_checks} ({overall:.0%})")
+    print(f"{'='*50}")
+
+    RESULTS_DIR.mkdir(exist_ok=True)
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    result_file = RESULTS_DIR / f"baseline_{timestamp}.json"
+    result_file.write_text(json.dumps({
+        "timestamp": timestamp,
+        "type": "baseline",
+        "overall_score": overall,
+        "total_passed": total_passed,
+        "total_checks": total_checks,
+        "scenarios": all_scores
+    }, indent=2))
+    print(f"💾 Results saved to {result_file}")
+
+    print("\n❌ Failed checks:")
+    for s in all_scores:
+        for check in s.get("checks", []):
+            if not check.get("pass"):
+                print(f"  [{s['scenario_id']}] {check['id']}: {check.get('reason', 'no reason')}")
+
+    return overall, all_scores
+
+
+def generate_improvement(all_scores, current_prompt):
+    """Use an LLM to suggest ONE targeted improvement based on failures."""
+    failures = []
+    for s in all_scores:
+        for check in s.get("checks", []):
+            if not check.get("pass"):
+                failures.append(f"[{s['scenario_id']}] {check['id']}: {check.get('reason', '')}")
+
+    if not failures:
+        print("✅ No failures to improve!")
+        return None
+
+    failures_text = "\n".join(failures)
+
+    improvement_prompt = f"""You are optimizing an AI receptionist's system prompt. Here are the criteria it FAILED:
+
+{failures_text}
+
+Current system prompt (first 500 chars for context):
+{current_prompt[:500]}...
+
+Rules:
+1. Suggest exactly ONE small, targeted change to the system prompt
+2. The change should fix the most common failure pattern
+3. Be specific — give the exact text to add/modify/remove
+4. Do NOT rewrite the whole prompt — surgical edit only
+5. Explain WHY this change should help
+
+Respond in JSON:
+{{"change_description": "what you're changing and why",
+ "search_text": "exact text in current prompt to find (or empty if adding new section)",
+ "replacement_text": "exact replacement text (or new text to add)",
+ "action": "replace|add_after|add_before"}}"""
+
+    result = subprocess.run(
+        ["python3", str(SCRIPT_DIR / "scorer.py"), improvement_prompt],
+        capture_output=True, text=True, timeout=120
+    )
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print(f"⚠️  Could not parse improvement suggestion: {result.stdout[:300]}")
+        return None
+
+
+def apply_improvement(prompt, improvement):
+    """Apply the suggested improvement to the prompt."""
+    action = improvement.get("action", "replace")
+    search = improvement.get("search_text", "")
+    replacement = improvement.get("replacement_text", "")
+
+    if action == "replace" and search:
+        if search in prompt:
+            return prompt.replace(search, replacement, 1)
+        else:
+            print(f"⚠️  Search text not found in prompt, appending instead")
+            return prompt + "\n" + replacement
+    elif action == "add_after" and search:
+        if search in prompt:
+            idx = prompt.index(search) + len(search)
+            return prompt[:idx] + "\n" + replacement + prompt[idx:]
+        else:
+            return prompt + "\n" + replacement
+    elif action == "add_before" and search:
+        if search in prompt:
+            idx = prompt.index(search)
+            return prompt[:idx] + replacement + "\n" + prompt[idx:]
+        else:
+            return prompt + "\n" + replacement
+    else:
+        return prompt + "\n" + replacement
+
+
+def run_improve():
+    """Run one improvement round."""
+    print("📥 Fetching current prompt...")
+    prompt = fetch_prompt()
+
+    print("\n📊 Scoring current state...")
+    baseline_score, baseline_results = run_baseline()
+
+    if baseline_score >= 0.95:
+        print("\n🎉 Score is already 95%+! Nothing to improve.")
+        return baseline_score
+
+    print("\n🧠 Analyzing failures and generating improvement...")
+    improvement = generate_improvement(baseline_results, prompt)
+
+    if not improvement:
+        print("⚠️  No improvement generated.")
+        return baseline_score
+
+    print(f"\n📝 Suggested change: {improvement.get('change_description', 'unknown')}")
+
+    new_prompt = apply_improvement(prompt, improvement)
+
+    print("\n🚀 Pushing improved prompt to server...")
+    push_prompt(new_prompt)
+
+    print("\n📊 Scoring improved version...")
+    new_score, new_results = run_baseline()
+
+    if new_score > baseline_score:
+        print(f"\n✅ IMPROVEMENT: {baseline_score:.0%} → {new_score:.0%}")
+        log_change(improvement, baseline_score, new_score, kept=True)
+        return new_score
+    else:
+        print(f"\n❌ NO IMPROVEMENT: {baseline_score:.0%} → {new_score:.0%}. Reverting...")
+        push_prompt(prompt)
+        log_change(improvement, baseline_score, new_score, kept=False)
+        return baseline_score
+
+
+def log_change(improvement, old_score, new_score, kept):
+    """Log the change to changelog."""
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+    status = "✅ KEPT" if kept else "❌ REVERTED"
+    entry = f"""
+## {timestamp} — {status}
+- **Change:** {improvement.get('change_description', 'unknown')}
+- **Score:** {old_score:.0%} → {new_score:.0%}
+- **Action:** {improvement.get('action', 'unknown')}
+"""
+    with open(CHANGELOG_FILE, "a") as f:
+        f.write(entry)
+
+
+def run_loop(rounds=5):
+    """Run multiple improvement rounds."""
+    print(f"🔄 Running {rounds} improvement rounds...\n")
+    score = 0
+    for i in range(rounds):
+        print(f"\n{'='*50}")
+        print(f"🔄 ROUND {i+1}/{rounds}")
+        print(f"{'='*50}")
+        score = run_improve()
+        if score >= 0.95:
+            print(f"\n🎉 Hit 95%+ after {i+1} rounds! Stopping.")
+            break
+    print(f"\n📊 Final score: {score:.0%}")
+
+
+def show_report():
+    """Show all results."""
+    if not RESULTS_DIR.exists():
+        print("No results yet. Run 'baseline' first.")
+        return
+
+    results = sorted(RESULTS_DIR.glob("*.json"))
+    for r in results:
+        data = json.loads(r.read_text())
+        print(f"{data['timestamp']} | {data['type']} | {data['overall_score']:.0%} ({data['total_passed']}/{data['total_checks']})")
+
+    if CHANGELOG_FILE.exists():
+        print(f"\n📋 Changelog:\n{CHANGELOG_FILE.read_text()}")
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "baseline"
+
+    if cmd == "baseline":
+        run_baseline()
+    elif cmd == "improve":
+        run_improve()
+    elif cmd == "loop":
+        rounds = int(sys.argv[2]) if len(sys.argv) > 2 else 5
+        run_loop(rounds)
+    elif cmd == "report":
+        show_report()
+    else:
+        print(__doc__)

--- a/tools/autoresearch/scenarios.json
+++ b/tools/autoresearch/scenarios.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": "new-client-basic",
+    "description": "New client calling to inquire about services",
+    "messages": [
+      "Hi, I'm looking for your services",
+      "I'm in downtown, my name is Sarah",
+      "555-123-4567",
+      "sarah@email.com"
+    ]
+  },
+  {
+    "id": "price-inquiry",
+    "description": "Caller focused on pricing before anything else",
+    "messages": [
+      "How much do you charge?",
+      "Just give me a ballpark",
+      "Fine, my name is Mike, I'm in the suburbs"
+    ]
+  },
+  {
+    "id": "existing-client",
+    "description": "Returning client with a follow-up question",
+    "messages": [
+      "Hey, I worked with you guys last month. I have a question about my service",
+      "Can you have someone call me back? They have my number"
+    ]
+  },
+  {
+    "id": "out-of-area",
+    "description": "Caller from outside the service area",
+    "messages": [
+      "Hi, I need your services. I'm in Portland, Oregon",
+      "Are you sure you can't help?"
+    ]
+  },
+  {
+    "id": "spam-vendor",
+    "description": "B2B vendor or marketing cold call",
+    "messages": [
+      "Hi, I'm calling from Marketing Solutions Inc. We can help you get more leads",
+      "Can I speak to the business owner?"
+    ]
+  },
+  {
+    "id": "off-topic-troll",
+    "description": "Caller asking irrelevant or inappropriate questions",
+    "messages": [
+      "What's your favorite color?",
+      "Do you like pizza?",
+      "Come on, just chat with me"
+    ]
+  },
+  {
+    "id": "spanish-speaker",
+    "description": "Spanish-speaking caller",
+    "messages": [
+      "Hola, necesito información sobre sus servicios",
+      "Estoy en el centro de la ciudad",
+      "Mi nombre es Carlos, mi número es 555-987-6543"
+    ]
+  }
+]

--- a/tools/autoresearch/scorer.py
+++ b/tools/autoresearch/scorer.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Scorer — Calls an LLM to evaluate receptionist responses.
+Takes a prompt as argv[1] or stdin, outputs JSON.
+
+Uses OpenRouter API. The API key is fetched from the remote server's .env
+to avoid storing secrets locally.
+"""
+
+import json
+import sys
+import urllib.request
+import ssl
+import subprocess
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+
+
+def _load_env():
+    env = {}
+    for line in (SCRIPT_DIR / ".env").read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            k, v = line.split("=", 1)
+            env[k.strip()] = v.strip()
+    return env
+
+
+_ENV = _load_env()
+
+# Fetch OpenRouter key from server (not stored locally)
+result = subprocess.run(
+    ["sshpass", "-p", _ENV["REMOTE_PASS"], "ssh", "-o", "StrictHostKeyChecking=no",
+     _ENV["REMOTE_HOST"], "grep -o 'OPENROUTER_API_KEY=.*' /opt/receptionist/.env | cut -d= -f2"],
+    capture_output=True, text=True, timeout=15
+)
+OPENROUTER_KEY = result.stdout.strip()
+
+if not OPENROUTER_KEY:
+    print(json.dumps({"error": "Could not fetch OpenRouter API key"}))
+    sys.exit(1)
+
+SCORER_MODEL = _ENV.get("SCORER_MODEL", "openai/gpt-4o")
+
+prompt = sys.argv[1] if len(sys.argv) > 1 else sys.stdin.read()
+
+payload = json.dumps({
+    "model": SCORER_MODEL,
+    "messages": [
+        {"role": "system", "content": "You are a strict evaluator. Respond ONLY in valid JSON. No markdown, no explanation outside JSON."},
+        {"role": "user", "content": prompt}
+    ],
+    "temperature": 0.1,
+    "max_tokens": 2000
+}).encode()
+
+req = urllib.request.Request(
+    "https://openrouter.ai/api/v1/chat/completions",
+    data=payload,
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {OPENROUTER_KEY}",
+    }
+)
+
+ctx = ssl.create_default_context()
+try:
+    with urllib.request.urlopen(req, context=ctx, timeout=60) as resp:
+        data = json.loads(resp.read())
+        content = data["choices"][0]["message"]["content"]
+        content = content.strip()
+        if content.startswith("```"):
+            content = content.split("\n", 1)[1] if "\n" in content else content[3:]
+        if content.endswith("```"):
+            content = content[:-3]
+        content = content.strip()
+        parsed = json.loads(content)
+        print(json.dumps(parsed))
+except Exception as e:
+    print(json.dumps({"error": str(e)}))
+    sys.exit(1)


### PR DESCRIPTION
Inspired by [Karpathy's autoresearch method](https://github.com/karpathy/autoresearch).

Automatically tests the receptionist's system prompt against simulated conversations, scores against configurable criteria, suggests improvements via LLM, and deploys only if score improves.

**What's included:**
- `tools/autoresearch/run.py` — baseline, improve, loop, report
- `tools/autoresearch/scorer.py` — LLM-based evaluator (OpenRouter)
- Example scenarios and criteria (customize per deployment)
- README with setup + automation guide

**How we use it at ChargeWizards:**
- 10 test scenarios (new lead, price shopper, spam, multi-language, etc.)
- Started at 56% → improved to 63% in 2 automated rounds
- Runs weekly via cron, auto-deploys improvements

The tool is fully generic — scenarios and criteria are JSON configs, no business logic in the code. Each deployment customizes their own test cases.

Single commit, clean branch off main.