### PR TITLE
Fix autofocus on touch devices + auto-terminate call on goodbye

### DIFF
--- a/public/chat-widget.js
+++ b/public/chat-widget.js
@@ -199,7 +199,7 @@
         fetchGreeting();
       }
 
-      chatInput.focus();
+      if (!('ontouchstart' in window)) { chatInput.focus(); }
     }
 
     function closeChat() {
@@ -270,7 +270,7 @@
       } finally {
         isBusy = false;
         chatInput.disabled = false;
-        chatInput.focus();
+        if (!('ontouchstart' in window)) { chatInput.focus(); }
       }
     });
 

--- a/public/chat.html
+++ b/public/chat.html
@@ -326,7 +326,7 @@
       // Re-enable input
       messageInput.disabled = false;
       sendBtn.disabled = false;
-      messageInput.focus();
+      if (!('ontouchstart' in window)) { messageInput.focus(); }
     });
     
     function addMessage(type, content) {
@@ -369,8 +369,8 @@
       chatForm.dispatchEvent(new Event('submit'));
     }
     
-    // Focus input on load
-    messageInput.focus();
+    // Focus input on load (skip on touch devices to avoid keyboard popup)
+    if (!('ontouchstart' in window)) { messageInput.focus(); }
   </script>
 </body>
 </html>

--- a/src/config.js
+++ b/src/config.js
@@ -37,7 +37,9 @@ function parseIntEnv(key, defaultValue) {
 
 const config = {
   twilio: {
-    phoneNumber: process.env.TWILIO_PHONE_NUMBER
+    phoneNumber: process.env.TWILIO_PHONE_NUMBER,
+    accountSid: process.env.TWILIO_ACCOUNT_SID || null,
+    authToken: process.env.TWILIO_AUTH_TOKEN || null,
   },
   openRouter: {
     apiKey: process.env.OPENROUTER_API_KEY,
@@ -86,6 +88,8 @@ const config = {
     ownerPhone: process.env.OWNER_PHONE || null,
     publicUrl: process.env.PUBLIC_URL || null,
   },
+  goodbyePhrases: (process.env.GOODBYE_PHRASES || 'goodbye,have a great day,take care,bye')
+    .split(',').map(p => p.trim()).filter(p => p),
   adminEmail: process.env.ADMIN_EMAIL || null,
   digestEnabled: (process.env.DIGEST_ENABLED || 'false').toLowerCase() === 'true',
   digestScheduleHour: parseInt(process.env.DIGEST_SCHEDULE_HOUR || '18', 10),

--- a/src/realtime/openai-adapter.js
+++ b/src/realtime/openai-adapter.js
@@ -150,6 +150,9 @@ class OpenAIAdapter extends ProviderAdapter {
         if (this.onTranscript && event.transcript) {
           this.onTranscript('assistant', event.transcript);
         }
+        if (event.transcript && this.goodbyeCallback && this._containsGoodbye(event.transcript)) {
+          this.goodbyeCallback();
+        }
         break;
 
       case 'conversation.item.input_audio_transcription.completed':
@@ -183,6 +186,19 @@ class OpenAIAdapter extends ProviderAdapter {
         }
         break;
     }
+  }
+
+  /**
+   * Returns true if the transcript contains any of the given phrases as whole words.
+   * @param {string} transcript
+   * @param {string[]} [phrases] - defaults to config.goodbyePhrases
+   * @returns {boolean}
+   */
+  _containsGoodbye(transcript, phrases) {
+    const list = phrases || config.goodbyePhrases;
+    return list.some(phrase =>
+      new RegExp(`\\b${phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i').test(transcript)
+    );
   }
 
   /**

--- a/src/server.js
+++ b/src/server.js
@@ -924,6 +924,18 @@ wss.on('connection', (ws) => {
             return;
           }
           
+          if (config.twilio.accountSid && config.twilio.authToken) {
+            const twilioClient = require('twilio')(config.twilio.accountSid, config.twilio.authToken);
+            adapter.goodbyeCallback = () => {
+              console.log(`👋 Goodbye detected — terminating call ${callSid} in 2.5s`);
+              setTimeout(() => {
+                twilioClient.calls(callSid).update({ status: 'completed' }).catch((err) => {
+                  console.error(`❌ Failed to terminate call ${callSid}:`, err.message);
+                });
+              }, 2500);
+            };
+          }
+
           relay = new RelayService(ws, adapter, callSid, streamSid, {
             from: callerPhone,
             to: twilioNumber

--- a/tests/unit/openai-adapter.test.js
+++ b/tests/unit/openai-adapter.test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+/**
+ * Unit tests for goodbye-phrase detection in OpenAIAdapter.
+ *
+ * Covers:
+ *  - goodbyeCallback is fired when transcript contains a default goodbye phrase
+ *  - goodbyeCallback is NOT fired on a partial match (word-boundary enforcement)
+ *  - goodbyeCallback is NOT fired when it is not set
+ *  - Detection is case-insensitive
+ *  - Custom phrase lists work correctly
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('ws', () => {
+  const MockWS = vi.fn();
+  MockWS.OPEN = 1;
+  return { default: MockWS };
+});
+
+vi.mock('../../src/config.js', () => ({
+  default: {
+    goodbyePhrases: ['goodbye', 'have a great day', 'take care', 'bye'],
+    realtime: { vad: { silenceDurationMs: 600, minSpeechDurationMs: 300, prefixPaddingMs: 300 } },
+    openai: { realtimeVoice: 'alloy' },
+  }
+}));
+
+import OpenAIAdapter from '../../src/realtime/openai-adapter.js';
+
+function makeAdapter() {
+  return new OpenAIAdapter('fake-api-key', 'alloy');
+}
+
+// ── _containsGoodbye — default phrases ───────────────────────────────────────
+
+describe('_containsGoodbye — default phrases', () => {
+  it('detects "goodbye" as a standalone word', () => {
+    const adapter = makeAdapter();
+    expect(adapter._containsGoodbye('Well, goodbye!')).toBe(true);
+  });
+
+  it('detects "have a great day"', () => {
+    const adapter = makeAdapter();
+    expect(adapter._containsGoodbye('Thanks for calling, have a great day!')).toBe(true);
+  });
+
+  it('detects "take care"', () => {
+    const adapter = makeAdapter();
+    expect(adapter._containsGoodbye('Take care and stay safe.')).toBe(true);
+  });
+
+  it('detects "bye"', () => {
+    const adapter = makeAdapter();
+    expect(adapter._containsGoodbye('Okay, bye!')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    const adapter = makeAdapter();
+    expect(adapter._containsGoodbye('GOODBYE!')).toBe(true);
+    expect(adapter._containsGoodbye('Bye')).toBe(true);
+  });
+
+  it('returns false for a transcript with no goodbye phrase', () => {
+    const adapter = makeAdapter();
+    expect(adapter._containsGoodbye('How can I help you today?')).toBe(false);
+  });
+});
+
+// ── _containsGoodbye — word-boundary enforcement ──────────────────────────────
+
+describe('_containsGoodbye — word-boundary enforcement (no false positives)', () => {
+  it('does NOT match "goodbye" inside a longer word like "goodbyecruel"', () => {
+    const adapter = makeAdapter();
+    expect(adapter._containsGoodbye('goodbyecruel world')).toBe(false);
+  });
+
+  it('does NOT match "bye" inside "bypass"', () => {
+    const adapter = makeAdapter();
+    // Pass explicit phrase list to isolate "bye" check
+    expect(adapter._containsGoodbye('I will bypass the issue', ['bye'])).toBe(false);
+  });
+
+  it('does NOT match "bye" as a substring inside "goodbye" (no boundary before b)', () => {
+    const adapter = makeAdapter();
+    // "goodbye" — 'b' in 'bye' is preceded by 'd', not a word boundary
+    expect(adapter._containsGoodbye('goodbye', ['bye'])).toBe(false);
+  });
+});
+
+// ── goodbyeCallback wiring ────────────────────────────────────────────────────
+
+describe('goodbyeCallback wiring via _handleMessage', () => {
+  it('fires goodbyeCallback when transcript matches a goodbye phrase', () => {
+    const adapter = makeAdapter();
+    const cb = vi.fn();
+    adapter.goodbyeCallback = cb;
+
+    adapter._handleMessage(JSON.stringify({
+      type: 'response.audio_transcript.done',
+      transcript: 'Thank you for calling! Goodbye!'
+    }));
+
+    expect(cb).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT fire goodbyeCallback when transcript has no goodbye phrase', () => {
+    const adapter = makeAdapter();
+    const cb = vi.fn();
+    adapter.goodbyeCallback = cb;
+
+    adapter._handleMessage(JSON.stringify({
+      type: 'response.audio_transcript.done',
+      transcript: 'Let me check on that appointment for you.'
+    }));
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('does NOT throw when goodbyeCallback is not set', () => {
+    const adapter = makeAdapter();
+    expect(() => {
+      adapter._handleMessage(JSON.stringify({
+        type: 'response.audio_transcript.done',
+        transcript: 'Goodbye!'
+      }));
+    }).not.toThrow();
+  });
+
+  it('does NOT fire goodbyeCallback on a partial match (bypass)', () => {
+    const adapter = makeAdapter();
+    const cb = vi.fn();
+    adapter.goodbyeCallback = cb;
+
+    adapter._handleMessage(JSON.stringify({
+      type: 'response.audio_transcript.done',
+      transcript: 'I will bypass the issue.'
+    }));
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+// ── custom phrase lists ───────────────────────────────────────────────────────
+
+describe('custom phrase list passed directly', () => {
+  it('matches a custom phrase', () => {
+    const adapter = makeAdapter();
+    expect(adapter._containsGoodbye('see you later, friend!', ['see you later', 'cheerio'])).toBe(true);
+    expect(adapter._containsGoodbye('cheerio!', ['see you later', 'cheerio'])).toBe(true);
+  });
+
+  it('does not match default phrases when only custom phrases are checked', () => {
+    const adapter = makeAdapter();
+    expect(adapter._containsGoodbye('goodbye', ['cheerio'])).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- **Closes #31 (S):** Guard all `input.focus()` calls in `chat-widget.js` and `chat.html` with `if (!('ontouchstart' in window))` — prevents the mobile keyboard from popping up unexpectedly when the chat opens or after sending a message. No behavior change on desktop.
- **Closes #30 (M):** Auto-terminate Twilio call when the AI says goodbye. Phrase matching uses word-boundary regex (no false positives on substrings like "bypass"). Termination fires 2.5s after detection to let audio finish. Phrases are configurable via `GOODBYE_PHRASES` env var. 15 unit tests added.

## Changes
- `public/chat-widget.js` — 2 focus calls guarded
- `public/chat.html` — 2 focus calls guarded
- `src/config.js` — adds `goodbyePhrases`, `twilio.accountSid`, `twilio.authToken`
- `src/realtime/openai-adapter.js` — adds `_containsGoodbye()` helper + fires `goodbyeCallback` on transcript match
- `src/server.js` — wires Twilio REST call in `goodbyeCallback` with 2.5s delay
- `tests/unit/openai-adapter.test.js` — 15 new unit tests (word-boundary, case-insensitive, callback wiring, custom phrases)

## Test plan
- [ ] Run `npx vitest run tests/unit/openai-adapter.test.js` — all 15 pass
- [ ] On a mobile device, open the chat widget — keyboard should NOT appear automatically
- [ ] On desktop, open the chat widget — input should still be focused
- [ ] With Twilio credentials set, confirm call terminates ~2.5s after AI delivers a goodbye phrase

🤖 Generated with [Claude Code](https://claude.com/claude-code)